### PR TITLE
Add semicolon to startup script

### DIFF
--- a/Assets/MobileCenter/MobileCenterCoreBehavior.cs
+++ b/Assets/MobileCenter/MobileCenterCoreBehavior.cs
@@ -27,7 +27,7 @@ public class MobileCenterCoreBehavior : MonoBehaviour
         }
         var appSecret = "ios=" + iOSAppSecret + 
                         ";android=" + AndroidAppSecret + 
-                        "uwp=" + UWPAppSecret + ";";
+                        ";uwp=" + UWPAppSecret + ";";
         MobileCenter.Start(appSecret);
     }
 }


### PR DESCRIPTION
There was a typo in the startup script. This PR fixes it.