### PR TITLE
Fix android permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,8 @@ Library/
 Assets/Plugins/Android/firebase-*
 Assets/Plugins/Android/support-*
 Assets/Plugins/Android/play-services-*
-Assets/Plugins/Android/res
-Assets/Plugins/Android/res.meta
+Assets/Plugins/Android/mobile-center/res
+Assets/Plugins/Android/mobile-center/res.meta
 Assets/Firebase/
 Assets/PlayServicesResolver/
 Assets/PlayServicesResolver.meta

--- a/Assets/Plugins/Android/mobile-center.meta
+++ b/Assets/Plugins/Android/mobile-center.meta
@@ -1,0 +1,34 @@
+fileFormatVersion: 2
+guid: 9211d4d5921ab7248b1b61ee65c56587
+folderAsset: yes
+timeCreated: 1502143352
+licenseType: Free
+PluginImporter:
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+    data:
+      first:
+        Android: Android
+      second:
+        enabled: 1
+        settings: {}
+    data:
+      first:
+        Any: 
+      second:
+        enabled: 0
+        settings: {}
+    data:
+      first:
+        Editor: Editor
+      second:
+        enabled: 0
+        settings:
+          DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Android/mobile-center/AndroidManifest.xml
+++ b/Assets/Plugins/Android/mobile-center/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.microsoft.azure.mobile.unity">
+  <uses-sdk android:minSdkVersion="15"/>
+</manifest>

--- a/Assets/Plugins/Android/mobile-center/AndroidManifest.xml.meta
+++ b/Assets/Plugins/Android/mobile-center/AndroidManifest.xml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b896d37c28e50e4e9c8ee1ea654f77a
+timeCreated: 1502144935
+licenseType: Free
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Android/mobile-center/project.properties
+++ b/Assets/Plugins/Android/mobile-center/project.properties
@@ -1,0 +1,3 @@
+# Project target.
+target=android-9
+android.library=true

--- a/Assets/Plugins/Android/mobile-center/project.properties.meta
+++ b/Assets/Plugins/Android/mobile-center/project.properties.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60a42348d13ec42489e3eaef83b8160a
+timeCreated: 1502144935
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Editor/FirebaseDependency.cs
+++ b/Assets/Plugins/Editor/FirebaseDependency.cs
@@ -16,7 +16,7 @@ public class FirebaseDependency : AssetPostprocessor
     private const string GoogleServicesFileBasename = "google-services";
     private const string GoogleServicesInputFile = GoogleServicesFileBasename + ".json";
     private const string GoogleServicesOutputFile = GoogleServicesFileBasename + ".xml";
-    private const string GoogleServicesOutputDirectory = "Assets/Plugins/Android/res/values";
+    private const string GoogleServicesOutputDirectory = "Assets/Plugins/Android/mobile-center/res/values";
     private const string GoogleServicesOutputPath = GoogleServicesOutputDirectory + "/" + GoogleServicesOutputFile;
 
     /// <summary>


### PR DESCRIPTION
Move resources from 'Assets/Plugins/Android/res' allows avoid problems with auto-adding permissions.