### PR TITLE
Re add uwp folder and remove from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ xcuserdata
 [Oo]bj/
 [Ll]og/
 /Temp/
-/UWP/
 /iOSBuild/
 /UWPBuild/
 /AndroidBuild/

--- a/UWP/project.json
+++ b/UWP/project.json
@@ -1,0 +1,16 @@
+﻿{
+  "dependencies": {
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
+  },
+  "frameworks": {
+    "uap10.0": {}
+  },
+  "runtimes": {
+    "win10-arm": {},
+    "win10-arm-aot": {},
+    "win10-x86": {},
+    "win10-x86-aot": {},
+    "win10-x64": {},
+    "win10-x64-aot": {}
+  }
+}


### PR DESCRIPTION
Not sure when the UWP folder was removed, but it isn't being generated at build time so is necessary for UWP builds to succeed.