### PR TITLE
Fix Android plugins, add appcenter-loader-release.aar to AppCenter.unitypackage

### DIFF
--- a/UnityPackageSpecs/AppCenter.unitypackagespec
+++ b/UnityPackageSpecs/AppCenter.unitypackagespec
@@ -10,6 +10,7 @@
         <!-- Android files -->
         <file path="Assets/AppCenter/Plugins/Android/Utility" />
         <file path="Assets/AppCenter/Plugins/Android/appcenter-release.aar" />
+        <file path="Assets/AppCenter/Plugins/Android/appcenter-loader-release.aar" />
         <file path="Assets/AppCenter/Plugins/AppCenterSDK/Core/Android" />
 
         <!-- Common files -->


### PR DESCRIPTION
Without appcenter-loader-release.aar App Center SDK for Android won't be started and none of the Unity SDK classes will work