### PR TITLE
Fix iOS build for case when only one unity package has been added to the project

### DIFF
--- a/Assets/AppCenter/Editor/AppCenterPreBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPreBuild.cs
@@ -1,12 +1,19 @@
 ﻿using System.IO;
 using UnityEditor;
 using UnityEditor.Build;
+#if UNITY_2018_1_OR_NEWER
 using UnityEditor.Build.Reporting;
+#endif
 
+#if UNITY_2018_1_OR_NEWER
 public class AppCenterPreBuild : IPreprocessBuildWithReport
+#else
+public class AppCenterPreBuild : IPreprocessBuild
+#endif
 {
     public int callbackOrder { get { return 0; } }
 
+#if UNITY_2018_1_OR_NEWER
     public void OnPreprocessBuild(BuildReport report)
     {
         if (report.summary.platform == BuildTarget.Android)
@@ -18,6 +25,19 @@ public class AppCenterPreBuild : IPreprocessBuildWithReport
             AddStartupCodeToiOS();
         }
     }
+#else
+    public void OnPreprocessBuild(BuildTarget target, string path)
+    {
+        if (target == BuildTarget.Android)
+        {
+            AddStartupCodeToAndroid();
+        }
+        else if (target == BuildTarget.iOS)
+        {
+            AddStartupCodeToiOS();
+        }
+    }
+#endif
 
     void AddStartupCodeToAndroid()
     {


### PR DESCRIPTION
Otherwise build fails when tries to compile some of this lines:
https://github.com/Microsoft/AppCenter-SDK-Unity/blob/develop/Assets/AppCenter/Plugins/iOS/Core/AppCenterStarter.original

```
#ifdef APPCENTER_UNITY_USE_PUSH
@import AppCenterPush;
#import "../Push/PushDelegate.h"
#endif

#ifdef APPCENTER_UNITY_USE_ANALYTICS
@import AppCenterAnalytics;
#endif

#ifdef APPCENTER_UNITY_USE_DISTRIBUTE
@import AppCenterDistribute;
#import "../Distribute/DistributeDelegate.h"
#endif
```

Also fixes warning:
```
IPreprocessBuild is obsolete, use IPreprocessBuildWithReport instead
```