### PR TITLE
Fix IPostprocessBuild is obsolete warning, use IPostprocessBuildWithReport in Unity 2018.1 or newer

### DIFF
--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -8,12 +8,27 @@ using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Build;
+#if UNITY_2018_1_OR_NEWER
+using UnityEditor.Build.Reporting;
+#endif
 
 // Warning: Don't use #if #endif for conditional compilation here as Unity
 // doesn't always set the flags early enough.
+
+#if UNITY_2018_1_OR_NEWER
+public class AppCenterPostBuild : IPostprocessBuildWithReport
+#else
 public class AppCenterPostBuild : IPostprocessBuild
+#endif
 {
     public int callbackOrder { get { return 0; } }
+
+#if UNITY_2018_1_OR_NEWER
+    public void OnPostprocessBuild(BuildReport report)
+    {
+        OnPostprocessBuild(report.summary.platform, report.summary.outputPath);
+    }
+#endif
 
     public void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
     {
@@ -249,7 +264,7 @@ public class AppCenterPostBuild : IPostprocessBuild
     }
 
     private static void OnPostprocessCapabilities(ProjectCapabilityManagerWrapper capabilityManager, AppCenterSettings settings)
-    {       
+    {
         if (settings.UsePush && AppCenterSettings.Push != null)
         {
             capabilityManager.AddPushNotifications();

--- a/Assets/AppCenter/Editor/AppCenterPreBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPreBuild.cs
@@ -16,16 +16,10 @@ public class AppCenterPreBuild : IPreprocessBuild
 #if UNITY_2018_1_OR_NEWER
     public void OnPreprocessBuild(BuildReport report)
     {
-        if (report.summary.platform == BuildTarget.Android)
-        {
-            AddStartupCodeToAndroid();
-        }
-        else if (report.summary.platform == BuildTarget.iOS)
-        {
-            AddStartupCodeToiOS();
-        }
+        OnPreprocessBuild(report.summary.platform, report.summary.outputPath);
     }
-#else
+#endif
+
     public void OnPreprocessBuild(BuildTarget target, string path)
     {
         if (target == BuildTarget.Android)
@@ -37,7 +31,6 @@ public class AppCenterPreBuild : IPreprocessBuild
             AddStartupCodeToiOS();
         }
     }
-#endif
 
     void AddStartupCodeToAndroid()
     {


### PR DESCRIPTION
If UNITY_2018_1_OR_NEWER is not defined then old interface IPostprocessBuild will be used

Also refactored code in AppCenterPreBuild class to remove code duplication