### PR TITLE
Set 'diagnostic' level of verbosity for build.ps1 script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -232,5 +232,5 @@ $cakeArguments += $ScriptArgs
 
 # Start Cake
 Write-Host "Running build script..."
-&$CAKE_EXE $cakeArguments --settings_skipverification=true
+&$CAKE_EXE $cakeArguments --settings_skipverification=true --verbosity=diagnostic
 exit $LASTEXITCODE


### PR DESCRIPTION
UNIX script already has diagnostics verbosity:
https://github.com/Microsoft/AppCenter-SDK-Unity/blob/11493fa2a26046e9da25e519fd1afbe6f9cea737/build.sh#L118

It is useful in case of errors and for file download progress