### PR TITLE
Do not force diagnostic verbosity in build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -115,4 +115,4 @@ fi
 
 # Start Cake
 # TODO remove "--settings_skipverification=true" as soon as addins support latest cake version
-exec mono "$CAKE_EXE" $SCRIPT "${CAKE_ARGUMENTS[@]}" --settings_skipverification=true --verbosity=diagnostic
+exec mono "$CAKE_EXE" $SCRIPT "${CAKE_ARGUMENTS[@]}" --settings_skipverification=true


### PR DESCRIPTION
You can active diagnostic verbosity on UNIX using this command:
```
./build.sh -verbosity=diagnostic
```

On Windows:
```
.\build.ps1 -Verbosity Diagnostic
```