### PR TITLE
Fix UWP build with crashes package added

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/UWP/Crashes.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/UWP/Crashes.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AppCenter.Crashes
 {
     // This is just a placeholder class since we don't support UWP crashes for now. When it's passed
     // to App Center, a message will be emitted that says it isn't yet supported.
-    class CrashesInternal
+    class Crashes
     {
     }
 }

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/UWP/WrapperExceptionInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/UWP/WrapperExceptionInternal.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
     {
         public static object Create()
         {
+            return new object();
         }
 
         public static void SetType(object exception, string type)


### PR DESCRIPTION
Right now if you add crashes package to your application you will encounter the following errors if you try to build UWP application:
1) Type Microsoft.AppCenter.Crashes.Crashes not resolved
This is because right now we do not download 'crashes' native SDK for UWP platform.
To works around we can use solution similar to what's been done for UWP's 'distribute' part - create our own empty Microsoft.AppCenter.Crashes.Crashes:
https://github.com/Microsoft/AppCenter-SDK-Unity/blob/5fedbddb2b7e0fd3e84cc4cab6a25dace2a1845c/Assets/AppCenter/Plugins/AppCenterSDK/Distribute/UWP/Distribute.cs#L9
There will be a message about this in application's log:
```
[AppCenter] ERROR: Failed to start service 'Crashes'; skipping it.
Microsoft.AppCenter.AppCenterException: Service type does not contain static 'Instance' property of type IAppCenterService
```

2) Missing return value from UWP's WrapperExceptionInternal.Create method.
Just return an empty object for now