### PR TITLE
Generate test crash on android

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
@@ -8,6 +8,7 @@ using Microsoft.AppCenter.Unity.Internal.Utility;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Microsoft.AppCenter.Unity.Crashes;
 
 namespace Microsoft.AppCenter.Unity.Crashes.Internal
 {
@@ -46,7 +47,7 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
 
         public static void GenerateTestCrash()
         {
-            _crashes.CallStatic("generateTestCrash");
+            Application.ForceCrash(1);
         }
 
         public static AppCenterTask<bool> HasCrashedInLastSession()
@@ -61,6 +62,14 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         }
 
         public static void DisableMachExceptionHandler()
+        {
+        }
+
+        public static void SetUserConfirmationHandler(Crashes.UserConfirmationHandler handler)
+        {
+        }
+
+        public static void NotifyWithUserConfirmation(Crashes.ConfirmationResult answer)
         {
         }
     }

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
             return new AppCenterTask<bool>(future);
         }
 
-        // We use Application.ForceCrash here instead of native call because AFAIK this is the only way that we know ti crash Unity Android application:
+        // We use Application.ForceCrash here instead of native call because AFAIK this is the only way that we know to crash Unity Android application:
         public static void GenerateTestCrash()
         {
             Application.ForceCrash(0);

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
@@ -44,12 +44,10 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
             return new AppCenterTask<bool>(future);
         }
 
-        // We use Application.ForceCrash here instead of native call because AFAIK this is the one of two known ways to crash Unity Android application:
-        // 1) Application.ForceCrash()
-        // 2) System.Diagnostics.Process.GetCurrentProcess().Kill()
+        // We use Application.ForceCrash here instead of native call because AFAIK this is the only way that we know ti crash Unity Android application:
         public static void GenerateTestCrash()
         {
-            Application.ForceCrash(1);
+            Application.ForceCrash(0);
         }
 
         public static AppCenterTask<bool> HasCrashedInLastSession()

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
@@ -8,7 +8,6 @@ using Microsoft.AppCenter.Unity.Internal.Utility;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using Microsoft.AppCenter.Unity.Crashes;
 
 namespace Microsoft.AppCenter.Unity.Crashes.Internal
 {

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
@@ -64,14 +64,6 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         public static void DisableMachExceptionHandler()
         {
         }
-
-        public static void SetUserConfirmationHandler(Crashes.UserConfirmationHandler handler)
-        {
-        }
-
-        public static void NotifyWithUserConfirmation(Crashes.ConfirmationResult answer)
-        {
-        }
     }
 }
 #endif

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
@@ -44,6 +44,9 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
             return new AppCenterTask<bool>(future);
         }
 
+        // We use Application.ForceCrash here instead of native call because AFAIK this is the one of two known ways to crash Unity Android application:
+        // 1) Application.ForceCrash()
+        // 2) System.Diagnostics.Process.GetCurrentProcess().Kill()
         public static void GenerateTestCrash()
         {
             Application.ForceCrash(1);


### PR DESCRIPTION
Undocumented Apllication.ForceCrash() Unity method is used to force crash on Android