### PR TITLE
Fix native SDK logs on UWP

### DIFF
--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -82,7 +82,7 @@ public class AppCenterPostBuild : IPostprocessBuild
     public static void AddHelperCodeToUWPProject(string pathToBuiltProject)
     {
         var settings = AppCenterSettingsContext.SettingsInstance;
-        if (!settings.UsePush)
+        if (!settings.UsePush || AppCenterSettings.Push == null)
         {
             return;
         }


### PR DESCRIPTION
Right now file `Debugger.cpp` with fixed logging is not being added to app because post-build script fails, when it tries to modify file from package, that hasn't been added to a project