### PR TITLE
Implemented Crashes.GetErrorAttachments for iOS

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesDelegate.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesDelegate.cs
@@ -39,6 +39,10 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         public static void SetShouldProcessErrorReportHandler(Crashes.ShouldProcessErrorReportHandler handler)
         {
         }
+
+        public static void SetGetErrorAttachmentsHandler(Crashes.GetErrorAttachmentstHandler handler)
+        {
+        }
     }
 }
 #endif

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Blank/CrashesDelegate.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Blank/CrashesDelegate.cs
@@ -15,6 +15,10 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         public static void SetShouldProcessErrorReportHandler(Crashes.ShouldProcessErrorReportHandler handler)
         {
         }
+
+        public static void SetGetErrorAttachmentsHandler(Crashes.GetErrorAttachmentstHandler handler)
+        {
+        }
     }
 }
 #endif

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Models/ErrorAttachmentLog.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Models/ErrorAttachmentLog.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Microsoft.AppCenter.Unity.Crashes
+{
+    public class ErrorAttachmentLog
+    {
+        public string Text { get; private set; }
+        public byte[] Data { get; private set; }
+        public string FileName { get; private set; }
+        public string ContentType { get; private set; }
+        public AttachmentType Type { get; private set; }
+
+        public static ErrorAttachmentLog AttachmentWithText(string text, string fileName)
+        {
+            var attachment = new ErrorAttachmentLog();
+            attachment.Text = text;
+            attachment.FileName = fileName;
+            attachment.Type = AttachmentType.Text;
+            return attachment;
+        }
+
+        public static ErrorAttachmentLog AttachmentWithBinary(byte[] data, string fileName, string contentType)
+        {
+            var attachment = new ErrorAttachmentLog();
+            attachment.Data = data;
+            attachment.FileName = fileName;
+            attachment.ContentType = contentType;
+            attachment.Type = AttachmentType.Binary;
+            return attachment;
+        }
+
+        public enum AttachmentType { Text, Binary }
+    }
+}

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Models/ErrorAttachmentLog.cs.meta
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Models/ErrorAttachmentLog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77bffd8d50b4648c4b9b1ae1553c31fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
@@ -184,6 +184,19 @@ namespace Microsoft.AppCenter.Unity.Crashes
             }
         }
 
+#if ENABLE_IL2CPP
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+#endif
+        public delegate ErrorAttachmentLog[] GetErrorAttachmentstHandler(ErrorReport errorReport);
+
+        public static GetErrorAttachmentstHandler GetErrorAttachments
+        {
+            set
+            {
+                CrashesDelegate.SetGetErrorAttachmentsHandler(value);
+            }
+        }
+
         public static void StartCrashes()
         {
             CrashesInternal.StartCrashes();

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/UWP/CrashesDelegate.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/UWP/CrashesDelegate.cs
@@ -11,6 +11,10 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         public static void SetShouldProcessErrorReportHandler(Crashes.ShouldProcessErrorReportHandler handler)
         {
         }
+
+        public static void SetGetErrorAttachmentsHandler(Crashes.GetErrorAttachmentstHandler handler)
+        {
+        }
     }
 }
 #endif

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/iOS/CrashesDelegate.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/iOS/CrashesDelegate.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Runtime.InteropServices;
 using AOT;
+using Microsoft.AppCenter.Unity.Crashes;
+using System.Collections.Generic;
 
 namespace Microsoft.AppCenter.Unity.Crashes.Internal
 {
@@ -16,10 +18,17 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         static NativeShouldProcessErrorReportDelegate del;
         static Crashes.ShouldProcessErrorReportHandler externalHandler = null;
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        delegate IntPtr NativeGetErrorAttachmentsDelegate(IntPtr report);
+        static NativeGetErrorAttachmentsDelegate delGetAttachments;
+        static Crashes.GetErrorAttachmentstHandler getErrorAttachmentsHandler = null;
+
         static CrashesDelegate()
         {
             del = ShouldProcessErrorReportNativeFunc;
             app_center_unity_crashes_crashes_delegate_set_should_process_error_report_delegate(del);
+            delGetAttachments = GetErrorAttachmentsNativeFunc;
+            app_center_unity_crashes_crashes_delegate_set_get_error_attachments_delegate(delGetAttachments);
         }
 
         public static void SetDelegate()
@@ -44,6 +53,39 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
             externalHandler = handler;
         }
 
+        [MonoPInvokeCallback(typeof(NativeGetErrorAttachmentsDelegate))]
+        public static IntPtr GetErrorAttachmentsNativeFunc(IntPtr report)
+        {
+            if (externalHandler != null)
+            {
+                ErrorReport errorReport = CrashesInternal.GetErrorReportFromIntPtr(report); 
+                ErrorAttachmentLog[] logs = getErrorAttachmentsHandler(errorReport);
+                List<IntPtr> nativeLogs = new List<IntPtr>();
+                foreach (ErrorAttachmentLog errorAttachmetLog in logs)
+                {
+                    IntPtr nativeLog = IntPtr.Zero;
+                    if (errorAttachmetLog.Type == ErrorAttachmentLog.AttachmentType.Text)
+                        nativeLog = app_center_unity_crashes_get_error_attachment_log_text(errorAttachmetLog.Text, errorAttachmetLog.FileName);
+                    else
+                        nativeLog = app_center_unity_crashes_get_error_attachment_log_binary(errorAttachmetLog.Data, errorAttachmetLog.Data.Length, errorAttachmetLog.FileName, errorAttachmetLog.ContentType);
+                    nativeLogs.Add(nativeLog);
+                }
+
+                IntPtr log0 = IntPtr.Zero;
+                if (nativeLogs.Count > 0) log0 = nativeLogs[0];
+                IntPtr log1 = IntPtr.Zero;
+                if (nativeLogs.Count > 1) log1 = nativeLogs[1];
+                return app_center_unity_create_error_attachments_array(log0, log1);
+            }
+            else
+                return IntPtr.Zero;
+        }
+
+        public static void SetGetErrorAttachmentsHandler(Crashes.GetErrorAttachmentstHandler handler)
+        {
+            getErrorAttachmentsHandler = handler;
+        }
+
 #region External
 
         [DllImport("__Internal")]
@@ -52,6 +94,17 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         [DllImport("__Internal")]
         private static extern void app_center_unity_crashes_crashes_delegate_set_should_process_error_report_delegate(NativeShouldProcessErrorReportDelegate functionPtr);
 
+        [DllImport("__Internal")]
+        private static extern void app_center_unity_crashes_crashes_delegate_set_get_error_attachments_delegate(NativeGetErrorAttachmentsDelegate functionPtr);
+
+        [DllImport("__Internal")]   
+        private static extern IntPtr app_center_unity_crashes_get_error_attachment_log_text(string text, string fileName);
+
+        [DllImport("__Internal")]   
+        private static extern IntPtr app_center_unity_crashes_get_error_attachment_log_binary(byte[] data, int size, string fileName, string contentType);
+
+        [DllImport("__Internal")]
+        private static extern IntPtr app_center_unity_create_error_attachments_array(IntPtr errorAttachment0, IntPtr errorAttachment1);
 #endregion
     }
 }

--- a/Assets/AppCenter/Plugins/iOS/Crashes/CrashesDelegate.h
+++ b/Assets/AppCenter/Plugins/iOS/Crashes/CrashesDelegate.h
@@ -5,8 +5,11 @@
 #import <AppCenterCrashes/AppCenterCrashes.h>
 #import <Foundation/Foundation.h>
 
-extern "C" void app_center_unity_crashes_crashes_delegate_set_should_process_error_report_delegate(bool(*handler)(MSErrorReport *));
 extern "C" void app_center_unity_crashes_set_delegate();
+extern "C" void app_center_unity_crashes_crashes_delegate_set_should_process_error_report_delegate(bool(*handler)(MSErrorReport *));
+extern "C" void app_center_unity_crashes_crashes_delegate_set_get_error_attachments_delegate(NSArray<MSErrorAttachmentLog *> *(*handler)(MSErrorReport *));
+
 @interface UnityCrashesDelegate : NSObject<MSCrashesDelegate>
 -(BOOL)crashes:(MSCrashes *)crashes shouldProcessErrorReport:(MSErrorReport *)errorReport;
+- (NSArray<MSErrorAttachmentLog *> *)attachmentsWithCrashes:(MSCrashes *)crashes forErrorReport:(MSErrorReport *)errorReport;
 @end

--- a/Assets/AppCenter/Plugins/iOS/Crashes/CrashesDelegate.mm
+++ b/Assets/AppCenter/Plugins/iOS/Crashes/CrashesDelegate.mm
@@ -7,18 +7,24 @@
 #import <Foundation/Foundation.h>
 
 static bool (*shouldProcessErrorReport)(MSErrorReport *);
+static NSArray<MSErrorAttachmentLog *>* (*getErrorAttachments)(MSErrorReport *);
 
 static UnityCrashesDelegate *unityCrashesDelegate = NULL;
+
+void app_center_unity_crashes_set_delegate()
+{
+    unityCrashesDelegate = [[UnityCrashesDelegate alloc] init];
+    [MSCrashes setDelegate:unityCrashesDelegate];
+}
 
 void app_center_unity_crashes_crashes_delegate_set_should_process_error_report_delegate(bool(*handler)(MSErrorReport *))
 {
     shouldProcessErrorReport = handler;
 }
 
-void app_center_unity_crashes_set_delegate()
+void app_center_unity_crashes_crashes_delegate_set_get_error_attachments_delegate(NSArray<MSErrorAttachmentLog *> *(*handler)(MSErrorReport *))
 {
-  unityCrashesDelegate = [[UnityCrashesDelegate alloc] init];
-  [MSCrashes setDelegate:unityCrashesDelegate];
+    getErrorAttachments = handler;
 }
 
 @implementation UnityCrashesDelegate
@@ -29,6 +35,14 @@ void app_center_unity_crashes_set_delegate()
         return (*shouldProcessErrorReport)(errorReport);
     else
         return true;
+}
+
+- (NSArray<MSErrorAttachmentLog *> *)attachmentsWithCrashes:(MSCrashes *)crashes forErrorReport:(MSErrorReport *)errorReport
+{
+    if (getErrorAttachments)
+        return (*getErrorAttachments)(errorReport);
+    else
+        return NULL;
 }
 
 @end

--- a/Assets/AppCenter/Plugins/iOS/Crashes/CrashesUnity.h
+++ b/Assets/AppCenter/Plugins/iOS/Crashes/CrashesUnity.h
@@ -20,5 +20,8 @@ extern "C" void* appcenter_unity_crashes_last_session_crash_report();
 extern "C" void appcenter_unity_crashes_set_user_confirmation_handler(bool(* userConfirmationHandler)());
 extern "C" void appcenter_unity_crashes_notify_with_user_confirmation(int userConfirmation);
 extern "C" void appcenter_unity_start_crashes();
+extern "C" void* app_center_unity_crashes_get_error_attachment_log_text(char* text, char* fileName);
+extern "C" void* app_center_unity_crashes_get_error_attachment_log_binary(unsigned char* data, int size, char* fileName, char* contentType);
+extern "C" void* app_center_unity_create_error_attachments_array(MSErrorAttachmentLog* log0, MSErrorAttachmentLog* log1);
 
 #endif

--- a/Assets/AppCenter/Plugins/iOS/Crashes/CrashesUnity.mm
+++ b/Assets/AppCenter/Plugins/iOS/Crashes/CrashesUnity.mm
@@ -8,6 +8,8 @@
 #import "CrashesDelegate.h"
 #import <Foundation/Foundation.h>
 #import <AppCenter/MSAppCenter.h>
+#import "AppCenterCrashes/MSErrorAttachmentLog.h"
+#import "NSStringHelper.h"
 
 void* appcenter_unity_crashes_get_type()
 {
@@ -70,4 +72,20 @@ void* appcenter_unity_crashes_last_session_crash_report()
 void appcenter_unity_start_crashes()
 {
     [MSAppCenter startService:MSCrashes.class];
+}
+
+void* app_center_unity_crashes_get_error_attachment_log_text(char* text, char* fileName)
+{
+    return (void *)CFBridgingRetain([[MSErrorAttachmentLog alloc] initWithFilename:appcenter_unity_cstr_to_ns_string(fileName) attachmentText:appcenter_unity_cstr_to_ns_string(text)]);
+}
+
+void* app_center_unity_crashes_get_error_attachment_log_binary(unsigned char* data, int size, char* fileName, char* contentType)
+{
+    return (void *)CFBridgingRetain([[MSErrorAttachmentLog alloc] initWithFilename:appcenter_unity_cstr_to_ns_string(fileName) attachmentBinary:[[NSData alloc] initWithBytes:data length:size] contentType:appcenter_unity_cstr_to_ns_string(contentType)]);
+}
+
+void* app_center_unity_create_error_attachments_array(MSErrorAttachmentLog* log0, MSErrorAttachmentLog* log1)
+{
+    NSArray<MSErrorAttachmentLog *>* errorAttachments = [NSArray arrayWithObjects:log0, log1, nil];
+    return (void *)CFBridgingRetain(errorAttachments);
 }

--- a/Assets/Puppet/PuppetAppCenter.cs
+++ b/Assets/Puppet/PuppetAppCenter.cs
@@ -21,6 +21,7 @@ public class PuppetAppCenter : MonoBehaviour
     {
         Crashes.ShouldProcessErrorReport = ShouldProcessErrorReportHandler;
         Crashes.ShouldAwaitUserConfirmation = UserConfirmationHandler;
+        Crashes.GetErrorAttachments = GetErrorAttachmentstHandler;
         instance = this;
     }
 
@@ -35,6 +36,17 @@ public class PuppetAppCenter : MonoBehaviour
     public static bool ShouldProcessErrorReportHandler(ErrorReport errorReport)
     {
         return true;
+    }
+
+    [MonoPInvokeCallback(typeof(Crashes.GetErrorAttachmentstHandler))]
+    public static ErrorAttachmentLog[] GetErrorAttachmentstHandler(ErrorReport errorReport)
+    {
+        byte[] bytes = new byte[] { 100, 101, 102, 103 };
+        return new ErrorAttachmentLog[]
+        {
+             ErrorAttachmentLog.AttachmentWithText("Hello world!", "hello.txt"),
+             ErrorAttachmentLog.AttachmentWithBinary(bytes, "fake_image.jpeg", "image/jpeg")
+        };
     }
 
     void OnEnable()


### PR DESCRIPTION
You can add one binary and one text attachment to a crash report. The SDK will send it along with the crash so that you can see it in App Center portal.