### PR TITLE
Fix 'Use of unassigned local variable' build error on ios

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/iOS/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/iOS/CrashesInternal.cs
@@ -91,10 +91,10 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
             var reporterSignal = app_center_unity_crashes_error_report_signal(errorReportPtr);
             var exceptionReason = app_center_unity_crashes_error_report_exception_reason(errorReportPtr);
             var startTime = app_center_unity_crashes_error_report_app_start_time(errorReportPtr);
-            DateTimeOffset dtoStart;
+            DateTimeOffset dtoStart = DateTimeOffset.UtcNow;
             if (startTime != null) dtoStart = DateTimeOffset.Parse(startTime);
             var errorTime = app_center_unity_crashes_error_report_app_error_time(errorReportPtr);
-            DateTimeOffset dtoError;
+            DateTimeOffset dtoError = DateTimeOffset.UtcNow;
             if (errorTime != null) dtoError = DateTimeOffset.Parse(errorTime);
             var isAppKill = app_center_unity_crashes_error_report_is_app_kill(errorReportPtr);
             var condition = exceptionName + " : " + exceptionReason;


### PR DESCRIPTION
Fix the following errors that occur during ios application build on latest version of Unity Editor for macOS:
`Assets/AppCenter/Plugins/AppCenterSDK/Crashes/iOS/CrashesInternal.cs(102,48): error CS0165: Use of unassigned local variable 'dtoStart'`
`Assets/AppCenter/Plugins/AppCenterSDK/Crashes/iOS/CrashesInternal.cs(102,58): error CS0165: Use of unassigned local variable 'dtoError'`