### PR TITLE
Remove appcenter-settings.xml.meta from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ output/
 AppCenterStarter.m
 AppCenterStarter.m.meta
 Assets/Plugins/Android/res/values/appcenter-settings.xml
+Assets/Plugins/Android/res/values/appcenter-settings.xml.meta
 
 # .NET Core
 project.lock.json

--- a/Assets/Plugins/Android/res/values/appcenter-settings.xml.meta
+++ b/Assets/Plugins/Android/res/values/appcenter-settings.xml.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 8b9d14eb59b42400993d237f94312afe
-timeCreated: 1515545148
-licenseType: Pro
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
This file is being generated during build.
Currently, when you open puppet app using Unity Editor or run build script the appcenter-settings.xml.meta file is being deleted, as there is no corresponding asset in the project