### PR TITLE
Allow other directories than Assets/AppCenter

### DIFF
--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -123,7 +123,7 @@ public class AppCenterPostBuild : IPostprocessBuild
 
     public static void InjectCodeToFile(string appFilePath, string searchRegex, string codeToInsertFileName, bool includeSearchText = true)
     {
-        var appAdditionsFolder = "Assets/AppCenter/Plugins/WSA/Push/AppAdditions";
+        var appAdditionsFolder = AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/WSA/Push/AppAdditions";
         var codeToInsert = File.ReadAllText(Path.Combine(appAdditionsFolder, codeToInsertFileName));
         var commentText = "App Center Push code:";
         codeToInsert = "\n            // " + commentText + "\n" + codeToInsert;
@@ -168,7 +168,7 @@ public class AppCenterPostBuild : IPostprocessBuild
 
     public static void ProcessUwpIl2CppDependencies()
     {
-        var binaries = AssetDatabase.FindAssets("*", new[] { "Assets/AppCenter/Plugins/WSA/IL2CPP" });
+        var binaries = AssetDatabase.FindAssets("*", new[] { AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/WSA/IL2CPP" });
         foreach (var guid in binaries)
         {
             var assetPath = AssetDatabase.GUIDToAssetPath(guid);

--- a/Assets/AppCenter/Editor/AppCenterPreBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPreBuild.cs
@@ -118,41 +118,41 @@ public class AppCenterPreBuild : IPreprocessBuild
 
     static bool IsAndroidDistributeAvailable()
     {
-        return File.Exists("Assets/AppCenter/Plugins/Android/appcenter-distribute-release.aar");
+        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-distribute-release.aar");
     }
 
     static bool IsAndroidPushAvailable()
     {
-        return File.Exists("Assets/AppCenter/Plugins/Android/appcenter-push-release.aar");
+        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-push-release.aar");
     }
 
     static bool IsAndroidAnalyticsAvailable()
     {
-        return File.Exists("Assets/AppCenter/Plugins/Android/appcenter-analytics-release.aar");
+        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-analytics-release.aar");
     }
 
     static bool IsAndroidCrashesAvailable()
     {
-        return File.Exists("Assets/AppCenter/Plugins/Android/appcenter-crashes-release.aar");
+        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-crashes-release.aar");
     }
 
     static bool IsIOSDistributeAvailable()
     {
-        return Directory.Exists("Assets/AppCenter/Plugins/iOS/Distribute");
+        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Distribute");
     }
 
     static bool IsIOSPushAvailable()
     {
-        return Directory.Exists("Assets/AppCenter/Plugins/iOS/Push");
+        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Push");
     }
 
     static bool IsIOSAnalyticsAvailable()
     {
-        return Directory.Exists("Assets/AppCenter/Plugins/iOS/Analytics");
+        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Analytics");
     }
 
     static bool IsIOSCrashesAvailable()
     {
-        return Directory.Exists("Assets/AppCenter/Plugins/iOS/Crashes");
+        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Crashes");
     }
 }

--- a/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
@@ -3,8 +3,9 @@ using UnityEditor;
 
 public class AppCenterSettingsContext : ScriptableObject
 {
-    private const string SettingsPath = "Assets/AppCenter/AppCenterSettings.asset";
-    private const string AdvancedSettingsPath = "Assets/AppCenter/AppCenterSettingsAdvanced.asset";
+    public const string AppCenterPath = "Assets";
+    private const string SettingsPath = AppCenterPath + "/AppCenter/AppCenterSettings.asset";
+    private const string AdvancedSettingsPath = AppCenterPath + "/AppCenter/AppCenterSettingsAdvanced.asset";
     public static AppCenterSettings SettingsInstance
     {
         get

--- a/Assets/AppCenter/Editor/AppCenterSettingsMakerIos.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsMakerIos.cs
@@ -6,8 +6,8 @@ using System.IO;
 
 public class AppCenterSettingsMakerIos
 {
-    private const string TemplateFilePath = "Assets/AppCenter/Plugins/iOS/Core/AppCenterStarter.original";
-    private const string TargetFilePath = "Assets/AppCenter/Plugins/iOS/Core/AppCenterStarter.m";
+    private const string TemplateFilePath = AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Core/AppCenterStarter.original";
+    private const string TargetFilePath = AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Core/AppCenterStarter.m";
     private const string AppSecretSearchText = "appcenter-app-secret";
     private const string TransmissionTargetTokenSearchText = "appcenter-transmission-target-token";
     private const string LogUrlSearchText = "custom-log-url";

--- a/Assets/Puppet/Editor/BuildPuppet.cs
+++ b/Assets/Puppet/Editor/BuildPuppet.cs
@@ -113,7 +113,7 @@ public class BuildPuppet
     private static void BuildPuppetScene(BuildTarget target, BuildTargetGroup targetGroup, ScriptingImplementation scriptingImplementation, string outputPath)
     {
         PlayerSettings.SetScriptingBackend(targetGroup, scriptingImplementation);
-        string[] puppetScene = { "Assets/Puppet/PuppetScene.unity" };
+        string[] puppetScene = { AppCenterSettingsContext.AppCenterPath + "/Puppet/PuppetScene.unity" };
         var options = new BuildPlayerOptions
         {
             scenes = puppetScene,


### PR DESCRIPTION
The path to AppCenter can now be specified in `AppCenterContext->AppCenterPath`.
_NOTE:_ The path to `appcenter-settings.xml` will still be `Assets/Plugins/Android/res/values/appcenter-settings.xml`