### PR TITLE
Fix typed properties parsing and serialization

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/UWP/AnalyticsInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/UWP/AnalyticsInternal.cs
@@ -5,6 +5,7 @@
 #if UNITY_WSA_10_0 && !UNITY_EDITOR
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Microsoft.AppCenter.Unity.Analytics.Internal
 {
@@ -12,6 +13,8 @@ namespace Microsoft.AppCenter.Unity.Analytics.Internal
 
     class AnalyticsInternal
     {
+        private static bool _warningLogged = false;
+
         public static void PrepareEventHandlers()
         {
         }
@@ -33,6 +36,12 @@ namespace Microsoft.AppCenter.Unity.Analytics.Internal
 
         public static void TrackEventWithProperties(string eventName, EventProperties properties)
         {
+            if (!_warningLogged)
+            {
+                Debug.LogWarning("Warning: Strongly typed properties are not supported on UWP platform. " +
+                    "All property values will be converted to strings for this and all the future calls.");
+                _warningLogged = true;
+            }
             UWPAnalytics.TrackEvent(eventName, properties.GetRawObject());
         }
 

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/UWP/EventPropertiesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/UWP/EventPropertiesInternal.cs
@@ -1,24 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 //
 // Licensed under the MIT license.
+
 #if UNITY_WSA_10_0 && !UNITY_EDITOR
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Globalization;
 
 namespace Microsoft.AppCenter.Unity.Analytics.Internal
 {
     class EventPropertiesInternal
     {
-        private static Dictionary<string, string> _properties;
-
         public static Dictionary<string, string> Create()
         {
-            if (_properties == null) 
-            {
-                _properties = new Dictionary<string, string>();
-            }
-            return _properties;
+            return new Dictionary<string, string>();
         }
 
         public static void SetString(Dictionary<string, string> properties, string key, string val)
@@ -28,23 +23,23 @@ namespace Microsoft.AppCenter.Unity.Analytics.Internal
 
         public static void SetNumber(Dictionary<string, string> properties, string key, long val)
         {
-            properties[key] = val.ToString();
+            properties[key] = val.ToString(CultureInfo.InvariantCulture);
         }
 
         public static void SetNumber(Dictionary<string, string> properties, string key, double val)
         {
-            properties[key] = val.ToString();
+            properties[key] = val.ToString(CultureInfo.InvariantCulture);
         }
 
         public static void SetBool(Dictionary<string, string> properties, string key, bool val)
         {
-            properties[key] = val.ToString();
+            properties[key] = val.ToString(CultureInfo.InvariantCulture);
         }
 
         public static void SetDate(Dictionary<string, string> properties, string key, DateTime val)
         {
             var format = "yyyy-MM-dd'T'HH:mm:ss.fffK";
-            var dateString = val.ToString(format);
+            var dateString = val.ToString(format, CultureInfo.InvariantCulture);
             properties[key] = dateString;
         }
     }

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/iOS/AnalyticsInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/iOS/AnalyticsInternal.cs
@@ -36,10 +36,6 @@ namespace Microsoft.AppCenter.Unity.Analytics.Internal
             appcenter_unity_analytics_track_event_with_properties(eventName, properties.Keys.ToArray(), properties.Values.ToArray(), properties.Count);
         }
 
-        public static void TrackEventWithProperties(string eventName, EventProperties properties)
-        {
-        }
-
         public static AppCenterTask SetEnabledAsync(bool isEnabled)
         {
             appcenter_unity_analytics_set_enabled(isEnabled);
@@ -52,7 +48,7 @@ namespace Microsoft.AppCenter.Unity.Analytics.Internal
             return AppCenterTask<bool>.FromCompleted(isEnabled);
         }
 
-        public static IntPtr GetTransmissionTarget(string transmissionTargetToken) 
+        public static IntPtr GetTransmissionTarget(string transmissionTargetToken)
         {
             return appcenter_unity_analytics_transmission_target_for_token(transmissionTargetToken);
         }

--- a/Assets/Puppet/PuppetEventProperty.cs
+++ b/Assets/Puppet/PuppetEventProperty.cs
@@ -5,6 +5,7 @@
 using Microsoft.AppCenter.Unity.Analytics;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -26,7 +27,7 @@ public class PuppetEventProperty : MonoBehaviour
                 properties.Set(Key.text, long.Parse(Value.text));
                 break;
             case 2: // Double
-                properties.Set(Key.text, double.Parse(Value.text));
+                properties.Set(Key.text, double.Parse(Value.text, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture));
                 break;
             case 3: // Boolean
                 properties.Set(Key.text, Boolean.isOn);


### PR DESCRIPTION
Fix property with `double` type parsing in puppet app on UWP
Fix property dictionary initialization on UWP
Use invariant culture to convert objects to strings