### PR TITLE
Fix errors for UWP with .Net scripting backend

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/UWP/EventPropertiesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/UWP/EventPropertiesInternal.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AppCenter.Unity.Analytics.Internal
 
         public static void SetBool(Dictionary<string, string> properties, string key, bool val)
         {
-            properties[key] = val.ToString(CultureInfo.InvariantCulture);
+            properties[key] = val.ToString();
         }
 
         public static void SetDate(Dictionary<string, string> properties, string key, DateTime val)

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
@@ -69,6 +69,7 @@ namespace Microsoft.AppCenter.Unity.Crashes
             }
         }
 
+#if !UNITY_WSA_10_0
         public static void OnHandleUnresolvedException(object sender, UnhandledExceptionEventArgs args)
         {
             if (args == null || args.ExceptionObject == null)
@@ -93,6 +94,7 @@ namespace Microsoft.AppCenter.Unity.Crashes
 #endif
             }
         }
+#endif
 
         public static AppCenterTask<bool> IsEnabledAsync()
         {
@@ -274,7 +276,7 @@ namespace Microsoft.AppCenter.Unity.Crashes
 
         private static void SubscribeToUnhandledExceptions()
         {
-#if !UNITY_EDITOR
+#if !UNITY_EDITOR && !UNITY_WSA_10_0
             Application.logMessageReceived += OnHandleLog;
             System.AppDomain.CurrentDomain.UnhandledException += OnHandleUnresolvedException;
 #endif
@@ -286,7 +288,7 @@ namespace Microsoft.AppCenter.Unity.Crashes
 
         private static void UnsubscribeFromUnhandledExceptions()
         {
-#if !UNITY_EDITOR
+#if !UNITY_EDITOR && !UNITY_WSA_10_0
             Application.logMessageReceived -= OnHandleLog;
             System.AppDomain.CurrentDomain.UnhandledException -= OnHandleUnresolvedException;
 #endif

--- a/Assets/Puppet/PuppetCrashes.cs
+++ b/Assets/Puppet/PuppetCrashes.cs
@@ -88,12 +88,14 @@ public class PuppetCrashes : MonoBehaviour
 
     public void ExceptionInNewThread()
     {
+#if !UNITY_WSA_10_0
         new Thread(() =>
         {
             Thread.Sleep(3000);
             object obj = null;
             obj.ToString();
         }).Start();
+#endif
     }
 
     public void LastCrashReport()


### PR DESCRIPTION
Fix errors for UWP with .Net scripting backend:
- `The type or namespace name 'UnhandledExceptionEventArgs' could not be found (are you missing a using directive or an assembly reference?)`
- `'Thread' does not contain a constructor that takes 1 arguments`
- `UWP\EventPropertiesInternal.cs(36,35): error CS1501: No overload for method 'ToString' takes 1 arguments`