### PR TITLE
Fixed comparisons with System.IntPtr and null

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/Shared/Analytics.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/Shared/Analytics.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AppCenter.Unity.Analytics
                 return null;
             }
             var internalObject = AnalyticsInternal.GetTransmissionTarget(transmissionTargetToken);
-            if (internalObject == null)
+            if (internalObject == IntPtr.Zero)
             {
                 return null;
             }

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/Shared/TransmissionTarget.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Analytics/Shared/TransmissionTarget.cs
@@ -105,7 +105,7 @@ namespace Microsoft.AppCenter.Unity.Analytics
                 return null;
             }
             var internalObject = TransmissionTargetInternal.GetTransmissionTarget(_rawObject, childTransmissionTargetToken);
-            if (internalObject == null)
+            if (internalObject == IntPtr.Zero)
             {
                 return null;
             }


### PR DESCRIPTION
This code generates the following warning:

warning CS0472: The result of comparing value type `System.IntPtr' with null is always `false'

It needs to compare against System.IntPtr.Zero rather than null.