### PR TITLE
Implement Crashes.StartCrashes method on Android

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Core/Android/AppCenterInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Core/Android/AppCenterInternal.cs
@@ -122,6 +122,16 @@ namespace Microsoft.AppCenter.Unity.Internal
             });
         }
 
+        public static void Start(Type service)
+        {
+            var nativeServiceTypes = ServicesToNativeTypes(new[] { service });
+            var startMethod = AndroidJNI.GetStaticMethodID(_appCenter.GetRawClass(), "start", "([Ljava/lang/Class;)V");
+            AndroidJNI.CallStaticVoidMethod(_appCenter.GetRawClass(), startMethod, new jvalue[]
+            {
+                new jvalue { l = nativeServiceTypes }
+            });
+        }
+
         private static AndroidJavaObject GetAndroidContext()
         {
             if (_context != null)

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Core/Blank/AppCenterInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Core/Blank/AppCenterInternal.cs
@@ -46,6 +46,10 @@ namespace Microsoft.AppCenter.Unity.Internal
         {
         }
 
+        public static void Start(ServiceType service)
+        {
+        }
+
         public static void StartFromLibrary(ServiceType[] services)
         {
         }

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Core/UWP/AppCenterInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Core/UWP/AppCenterInternal.cs
@@ -39,6 +39,10 @@ namespace Microsoft.AppCenter.Unity.Internal
             UWPAppCenter.Start(nativeServiceTypes);
         }
 
+        public static void Start(Type service)
+        {
+        }
+
         public static string GetSdkVersion()
         {
             return "";

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Core/iOS/AppCenterInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Core/iOS/AppCenterInternal.cs
@@ -94,6 +94,10 @@ namespace Microsoft.AppCenter.Unity.Internal
             appcenter_unity_start_no_secret(nativeServiceTypes, nativeServiceTypes.Length);
         }
 
+        public static void Start(Type service)
+        {
+        }
+
         public static void StartFromLibrary(IntPtr[] services)
         {
             appcenter_unity_start_from_library(services, services.Length);

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Microsoft.AppCenter.Unity.Crashes;
+using Microsoft.AppCenter.Unity.Internal;
 
 namespace Microsoft.AppCenter.Unity.Crashes.Internal
 {
@@ -75,6 +76,7 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
 
         public static void StartCrashes()
         {
+            AppCenterInternal.Start(AppCenter.Crashes);
         }
     }
 }


### PR DESCRIPTION
Allow application to set custom user ID using the `AppCenter.SetUserId` method and then start Crashes service of the native SDK using the `Crashes.StartCrashes` method to send pending crash reports with correct user ID