### PR TITLE
Delete AppCenterSettingsAdvanced.asset when script was removed from GameObject and prevent creating the second AppCenter instance in the editor.

### DIFF
--- a/Assets/AppCenter/AppCenterBehavior.cs
+++ b/Assets/AppCenter/AppCenterBehavior.cs
@@ -43,22 +43,16 @@ public class AppCenterBehavior : MonoBehaviour
 #endif
     }
 
+#if UNITY_EDITOR
     public void Reset()
     {
-        if (GetComponentInstances().Length > 1)
+        if (FindObjectsOfType<AppCenterBehavior>().Length > 1)
         {
             Debug.LogError("Only one game object with App Center Behaviour should exist.");
             DestroyImmediate(this);
         }
     }
-
-    public static AppCenterBehavior[] GetComponentInstances()
-    {
-        var rootObjects = UnityEngine.SceneManagement.SceneManager.GetActiveScene().GetRootGameObjects();
-
-        return rootObjects.Select(obj => obj.GetComponentsInChildren<AppCenterBehavior>())
-            .Aggregate((first, next) => first.Concat(next).ToArray());
-    }
+#endif
 
     private void StartAppCenter()
     {

--- a/Assets/AppCenter/AppCenterBehavior.cs
+++ b/Assets/AppCenter/AppCenterBehavior.cs
@@ -43,6 +43,23 @@ public class AppCenterBehavior : MonoBehaviour
 #endif
     }
 
+    public void Reset()
+    {
+        if (GetComponentInstances().Length > 1)
+        {
+            Debug.LogError("Only one game object with App Center Behaviour should exist.");
+            DestroyImmediate(this);
+        }
+    }
+
+    public static AppCenterBehavior[] GetComponentInstances()
+    {
+        var rootObjects = UnityEngine.SceneManagement.SceneManager.GetActiveScene().GetRootGameObjects();
+
+        return rootObjects.Select(obj => obj.GetComponentsInChildren<AppCenterBehavior>())
+            .Aggregate((first, next) => first.Concat(next).ToArray());
+    }
+
     private void StartAppCenter()
     {
         if (Settings == null)

--- a/Assets/AppCenter/AppCenterBehaviorAdvanced.cs
+++ b/Assets/AppCenter/AppCenterBehaviorAdvanced.cs
@@ -21,14 +21,14 @@ public class AppCenterBehaviorAdvanced : MonoBehaviour
 
     public void Reset()
     {
-        if (GetAllInstances().Length > 1)
+        if (GetComponentInstances().Length > 1)
         {
             Debug.LogError("Only one game object with App Center Behaviour Advanced should exist.");
             DestroyImmediate(this);
         }
     }
 
-    public static AppCenterBehaviorAdvanced[] GetAllInstances()
+    public static AppCenterBehaviorAdvanced[] GetComponentInstances()
     {
         var rootObjects = UnityEngine.SceneManagement.SceneManager.GetActiveScene().GetRootGameObjects();
 

--- a/Assets/AppCenter/AppCenterBehaviorAdvanced.cs
+++ b/Assets/AppCenter/AppCenterBehaviorAdvanced.cs
@@ -2,7 +2,6 @@
 //
 // Licensed under the MIT license.
 
-using System.Linq;
 using UnityEngine;
 
 [HelpURL("https://docs.microsoft.com/en-us/appcenter/sdk/crashes/unity")]
@@ -19,20 +18,14 @@ public class AppCenterBehaviorAdvanced : MonoBehaviour
         }
     }
 
+#if UNITY_EDITOR
     public void Reset()
     {
-        if (GetComponentInstances().Length > 1)
+        if (FindObjectsOfType<AppCenterBehaviorAdvanced>().Length > 1)
         {
             Debug.LogError("Only one game object with App Center Behaviour Advanced should exist.");
             DestroyImmediate(this);
         }
     }
-
-    public static AppCenterBehaviorAdvanced[] GetComponentInstances()
-    {
-        var rootObjects = UnityEngine.SceneManagement.SceneManager.GetActiveScene().GetRootGameObjects();
-
-        return rootObjects.Select(obj => obj.GetComponentsInChildren<AppCenterBehaviorAdvanced>())
-            .Aggregate((first, next) => first.Concat(next).ToArray());
-    }
+#endif
 }

--- a/Assets/AppCenter/AppCenterBehaviorAdvanced.cs
+++ b/Assets/AppCenter/AppCenterBehaviorAdvanced.cs
@@ -2,6 +2,7 @@
 //
 // Licensed under the MIT license.
 
+using System.Linq;
 using UnityEngine;
 
 [HelpURL("https://docs.microsoft.com/en-us/appcenter/sdk/crashes/unity")]
@@ -16,5 +17,22 @@ public class AppCenterBehaviorAdvanced : MonoBehaviour
         {
             Debug.LogError("App Center Behavior Advanced should have the App Center Behavior instance attached to the same game object.");
         }
+    }
+
+    public void Reset()
+    {
+        if (GetAllInstances().Length > 1)
+        {
+            Debug.LogError("Only one game object with App Center Behaviour Advanced should exist.");
+            DestroyImmediate(this);
+        }
+    }
+
+    public static AppCenterBehaviorAdvanced[] GetAllInstances()
+    {
+        var rootObjects = UnityEngine.SceneManagement.SceneManager.GetActiveScene().GetRootGameObjects();
+
+        return rootObjects.Select(obj => obj.GetComponentsInChildren<AppCenterBehaviorAdvanced>())
+            .Aggregate((first, next) => first.Concat(next).ToArray());
     }
 }

--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
@@ -29,7 +29,7 @@ public class AppCenterBehaviorEditorAdvanced : Editor
     public void OnDestroy()
     {
         // If the component is removed from GameObject then remove the related asset.
-        if (!target && AppCenterBehaviorAdvanced.GetComponentInstances().Length == 0)
+        if (!target && FindObjectsOfType<AppCenterBehaviorAdvanced>().Length == 0)
         {
             AppCenterSettingsContext.DeleteSettingsInstanceAdvanced();
         }

--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
@@ -28,7 +28,7 @@ public class AppCenterBehaviorEditorAdvanced : Editor
 
     public void OnDestroy()
     {
-        // If the component is removed from GO then remove the related asset.
+        // If the component is removed from GameObject then remove the related asset.
         if (!this.target)
         {
             AppCenterSettingsContext.DeleteSettingsInstanceAdvanced();

--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
@@ -25,4 +25,9 @@ public class AppCenterBehaviorEditorAdvanced : Editor
         }
         settingsEditorAdvanced.OnInspectorGUI();
     }
+
+    public void OnDisable()
+    {
+        AppCenterSettingsContext.DeleteSettingsInstanceAdvanced();
+    }
 }

--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
@@ -26,8 +26,12 @@ public class AppCenterBehaviorEditorAdvanced : Editor
         settingsEditorAdvanced.OnInspectorGUI();
     }
 
-    public void OnDisable()
+    public void OnDestroy()
     {
-        AppCenterSettingsContext.DeleteSettingsInstanceAdvanced();
+        // If the component is removed from GO then remove the related asset.
+        if (!this.target)
+        {
+            AppCenterSettingsContext.DeleteSettingsInstanceAdvanced();
+        }
     }
 }

--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
@@ -29,7 +29,7 @@ public class AppCenterBehaviorEditorAdvanced : Editor
     public void OnDestroy()
     {
         // If the component is removed from GameObject then remove the related asset.
-        if (!this.target)
+        if (!target && AppCenterBehaviorAdvanced.GetAllInstances().Length == 0)
         {
             AppCenterSettingsContext.DeleteSettingsInstanceAdvanced();
         }

--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditorAdvanced.cs
@@ -29,7 +29,7 @@ public class AppCenterBehaviorEditorAdvanced : Editor
     public void OnDestroy()
     {
         // If the component is removed from GameObject then remove the related asset.
-        if (!target && AppCenterBehaviorAdvanced.GetAllInstances().Length == 0)
+        if (!target && AppCenterBehaviorAdvanced.GetComponentInstances().Length == 0)
         {
             AppCenterSettingsContext.DeleteSettingsInstanceAdvanced();
         }

--- a/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
@@ -43,4 +43,9 @@ public class AppCenterSettingsContext : ScriptableObject
         }
         return instance;
     }
+
+    public static void DeleteSettingsInstanceAdvanced()
+    {
+        AssetDatabase.DeleteAsset(AdvancedSettingsPath);
+    }
 }


### PR DESCRIPTION
Changes:

1. AppCenterSettingsAdvanced.asset will be deleted when component AppCenterBehaviorAdvanced is removed from GameObject. It was done to fix an issue: AppCenter Analytics could work incorrectly in case we have no advanced behavior but this file exists.

1. Added checking that AppCenterBehaviour (and AppCenterBehaviourAdvanced) is single. It was done to prevent a user creates the second GameObject with AppCenter behaviors. If the user tries to do this then warning will be shown and the script will not be added to GameObject.