### PR TITLE
Added implementation of methods for Crashes for Android.

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesDelegate.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesDelegate.cs
@@ -13,14 +13,18 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         public static event Crashes.SentErrorReportHandler SentErrorReport;
         public static event Crashes.FailedToSendErrorReportHandler FailedToSendErrorReport;
 
+        private static readonly CrashesDelegate instance = new CrashesDelegate();
+
+        private Crashes.UserConfirmationHandler shouldAwaitUserConfirmationHandler = null;
+
         private CrashesDelegate() : base("com.microsoft.appcenter.crashes.CrashesListener")
         {
         }
 
         public static void SetDelegate()
         {
-            //var crashes = new AndroidJavaClass("com.microsoft.appcenter.crashes.Crashes");
-            //crashes.CallStatic("setListener", new CrashesDelegate());
+            var crashes = new AndroidJavaClass("com.microsoft.appcenter.crashes.Crashes");
+            crashes.CallStatic("setListener", instance);
         }
 
         //TODO bind error report; implement these
@@ -43,12 +47,22 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
 
         public bool shouldAwaitUserConfirmation()
         {
+            if (instance.shouldAwaitUserConfirmationHandler != null)
+            {
+                return instance.shouldAwaitUserConfirmationHandler.Invoke();
+            }
+
             return false;
         }
 
         public AndroidJavaObject getErrorAttachments(AndroidJavaObject report)
         {
             return null;
+        }
+
+        public static void SetShouldAwaitUserConfirmationHandler(Crashes.UserConfirmationHandler handler)
+        {
+            instance.shouldAwaitUserConfirmationHandler = handler;
         }
 
         public static void SetShouldProcessErrorReportHandler(Crashes.ShouldProcessErrorReportHandler handler)

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
@@ -19,6 +19,8 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         private static AndroidJavaClass _crashes = new AndroidJavaClass("com.microsoft.appcenter.crashes.Crashes");
         private static AndroidJavaClass _wrapperSdkExceptionManager = new AndroidJavaClass("com.microsoft.appcenter.crashes.WrapperSdkExceptionManager");
 
+        private static Crashes.UserConfirmationHandler userConfirmationHandler;
+
         public static void AddNativeType(List<IntPtr> nativeTypes)
         {
             nativeTypes.Add(AndroidJNI.FindClass("com/microsoft/appcenter/crashes/Crashes"));
@@ -88,6 +90,7 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
 
         public static void SetUserConfirmationHandler(Crashes.UserConfirmationHandler handler)
         {
+            CrashesDelegate.SetShouldAwaitUserConfirmationHandler(handler);
         }
 
         public static void NotifyWithUserConfirmation(Crashes.ConfirmationResult answer)

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Android/CrashesInternal.cs
@@ -92,11 +92,30 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
 
         public static void NotifyWithUserConfirmation(Crashes.ConfirmationResult answer)
         {
+            _crashes.CallStatic("notifyUserConfirmation", ToJavaConfirmationResult(answer));
         }
 
         public static void StartCrashes()
         {
             AppCenterInternal.Start(AppCenter.Crashes);
+        }
+
+        private static int ToJavaConfirmationResult(Crashes.ConfirmationResult answer)
+        {
+            // Java values: SEND=0, DONT_SEND=1, ALWAYS_SEND=2
+            // Crashes.ConfirmationResult values: SEND=1, DONT_SEND=0, ALWAYS_SEND=2
+            switch (answer)
+            {
+                case Crashes.ConfirmationResult.Send:
+                    return _crashes.GetStatic<int>("SEND");
+
+                case Crashes.ConfirmationResult.AlwaysSend:
+                    return _crashes.GetStatic<int>("ALWAYS_SEND");
+
+                default:
+                case Crashes.ConfirmationResult.DontSend:
+                    return _crashes.GetStatic<int>("DONT_SEND");
+            }
         }
     }
 }

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Blank/CrashesDelegate.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Blank/CrashesDelegate.cs
@@ -33,6 +33,10 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         public static void SetFailedToSendErrorReportHandler(Crashes.FailedToSendErrorReportHandler handler)
         {
         }
+
+        public static void SetShouldAwaitUserConfirmationHandler(Crashes.UserConfirmationHandler handler)
+        {
+        }
     }
 }
 #endif

--- a/Assets/Puppet/PuppetAppCenter.cs
+++ b/Assets/Puppet/PuppetAppCenter.cs
@@ -97,20 +97,8 @@ public class PuppetAppCenter : MonoBehaviour
             _customUserId = customUserId;
             AppCenter.SetUserId(customUserId);
         }
-        Crashes.ShouldProcessErrorReport = PuppetCrashes.ShouldProcessErrorReportHandler;
-        Crashes.ShouldAwaitUserConfirmation = UserConfirmationHandler;
-        Crashes.GetErrorAttachments = PuppetCrashes.GetErrorAttachmentstHandler;
-        Crashes.SendingErrorReport += PuppetCrashes.SendingErrorReportHandler;
-        Crashes.SentErrorReport += PuppetCrashes.SentErrorReportHandler;
-        Crashes.FailedToSendErrorReport += PuppetCrashes.FailedToSendErrorReportHandler;
-        instance = this;
-    }
 
-    [MonoPInvokeCallback(typeof(Crashes.UserConfirmationHandler))]
-    public static bool UserConfirmationHandler()
-    {
-        instance.userConfirmationDialog.Show();
-        return true;
+        instance = this;
     }
 
     void OnEnable()

--- a/Assets/Puppet/PuppetCrashDialogHandler.cs
+++ b/Assets/Puppet/PuppetCrashDialogHandler.cs
@@ -1,0 +1,48 @@
+﻿using AOT;
+using Microsoft.AppCenter.Unity.Crashes;
+using UnityEngine;
+
+public class PuppetCrashDialogHandler : MonoBehaviour
+{
+    public PuppetConfirmationDialog ConfirmationDialog;
+
+    private static object uiLocker = new object();
+    private static bool shouldShowDialog;
+
+    private void Awake()
+    {
+        Crashes.ShouldAwaitUserConfirmation = UserConfirmationHandler;
+        Crashes.ShouldProcessErrorReport = PuppetCrashes.ShouldProcessErrorReportHandler;
+        Crashes.GetErrorAttachments = PuppetCrashes.GetErrorAttachmentstHandler;
+        Crashes.SendingErrorReport += PuppetCrashes.SendingErrorReportHandler;
+        Crashes.SentErrorReport += PuppetCrashes.SentErrorReportHandler;
+        Crashes.FailedToSendErrorReport += PuppetCrashes.FailedToSendErrorReportHandler;
+    }
+
+    [MonoPInvokeCallback(typeof(Crashes.UserConfirmationHandler))]
+    public static bool UserConfirmationHandler()
+    {
+        shouldShowDialog = true;
+        return true;
+    }
+
+    void Update()
+    {
+        if (shouldShowDialog)
+        {
+            lock (uiLocker)
+            {
+                ConfirmationDialog.Show();
+                shouldShowDialog = false;
+            }
+        }
+    }
+
+#if UNITY_EDITOR
+    [ContextMenu("Test crash dialog")]
+    void TestShowDialog()
+    {
+        shouldShowDialog = true;
+    }
+#endif
+}

--- a/Assets/Puppet/PuppetCrashDialogHandler.cs.meta
+++ b/Assets/Puppet/PuppetCrashDialogHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16e78ec24bddc624e9f7d7969e9b48d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Puppet/PuppetScene.unity
+++ b/Assets/Puppet/PuppetScene.unity
@@ -8930,7 +8930,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1111163099}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.45983353
+  m_Size: 0.45805094
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -21231,6 +21231,7 @@ GameObject:
   - component: {fileID: 1653541464}
   - component: {fileID: 1653541465}
   - component: {fileID: 1653541466}
+  - component: {fileID: 1653541463}
   m_Layer: 0
   m_Name: App Center
   m_TagString: Untagged
@@ -21238,6 +21239,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!114 &1653541463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1653541462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 16e78ec24bddc624e9f7d7969e9b48d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ConfirmationDialog: {fileID: 1399467467}
 --- !u!114 &1653541464
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Added implementation of methods:

1. `SetUserConfirmationHandler`
2. `NotifyWithUserConfirmation`

Created component `PuppetCrashDialogHandler`, moved code from `PuppetAppCenter.cs` to this. 
Crash report dialog should be shown at the next run after application crash.