### PR TITLE
Fixed warnings when UI-components were changed from not-UI threads.

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Core/Shared/AppCenter.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Core/Shared/AppCenter.cs
@@ -19,9 +19,9 @@ namespace Microsoft.AppCenter.Unity
 
     public class AppCenter
     {
-        private static AppCenterTask<string> _secretTask;
-        private static AppCenterTask<string> _logUrlTask;
-        private static AppCenterTask<long> _storageSizeTask;
+        private static AppCenterTask<string> _secretTask = new AppCenterTask<string>();
+        private static AppCenterTask<string> _logUrlTask = new AppCenterTask<string>();
+        private static AppCenterTask<long> _storageSizeTask = new AppCenterTask<long>();
 
         public static LogLevel LogLevel
         {

--- a/Assets/Puppet/PuppetAppCenter.cs
+++ b/Assets/Puppet/PuppetAppCenter.cs
@@ -101,40 +101,49 @@ public class PuppetAppCenter : MonoBehaviour
 
     void OnEnable()
     {
-        AppCenter.IsEnabledAsync().ContinueWith(task =>
+        StartCoroutine(OnEnableCoroutine());
+        StartCoroutine(ShowCustomLogUrl());
+    }
+
+    private IEnumerator ShowCustomLogUrl()
+    {
+        var logUrl = AppCenter.GetLogUrl();
+        yield return logUrl;
+        LogUrlLabel.text = logUrl.Result;
+    }
+
+    private IEnumerator OnEnableCoroutine()
+    {
+        var isEnabled = AppCenter.IsEnabledAsync();
+        yield return isEnabled;
+        Enabled.isOn = isEnabled.Result;
+
+        var installId = AppCenter.GetInstallIdAsync();
+        yield return installId;
+        if (installId.Result.HasValue)
         {
-            Enabled.isOn = task.Result;
-        });
-        AppCenter.GetInstallIdAsync().ContinueWith(task =>
-        {
-            if (task.Result.HasValue)
-            {
-                InstallIdLabel.text = task.Result.ToString();
-            }
-        });
-        AppCenter.GetSecretForPlatform().ContinueWith(task =>
-        {
-            AppSecretLabel.text = task.Result;
-        });
-        AppCenter.GetLogUrl().ContinueWith(task =>
-        {
-            LogUrlLabel.text = task.Result;
-        });
-        AppCenter.GetStorageSize().ContinueWith(task =>
-        {
-            StorageSizeLabel.text = task.Result <= 0 ? "Unchanged" : task.Result.ToString() + " bytes";
-        });
+            InstallIdLabel.text = installId.Result.ToString();
+        }
+
+        var appSecret = AppCenter.GetSecretForPlatform();
+        yield return appSecret;
+        AppSecretLabel.text = appSecret.Result;
+
+        var storageSize = AppCenter.GetStorageSize();
+        yield return storageSize;
+        StorageSizeLabel.text = storageSize.Result <= 0 ? "Unchanged" : storageSize.Result.ToString() + " bytes";
+
         DeviceIdLabel.text = SystemInfo.deviceUniqueIdentifier;
         SdkVersionLabel.text = AppCenter.GetSdkVersion();
         LogLevel.value = AppCenter.LogLevel - Microsoft.AppCenter.Unity.LogLevel.Verbose;
-        Push.IsEnabledAsync().ContinueWith(task =>
-        {
-            PushEnabled.isOn = task.Result;
-        });
-        Distribute.IsEnabledAsync().ContinueWith(task =>
-        {
-            DistributeEnabled.isOn = task.Result;
-        });
+
+        var isPushEnabled = Push.IsEnabledAsync();
+        yield return isPushEnabled;
+        PushEnabled.isOn = isPushEnabled.Result;
+
+        var isDistributeEnabled = Distribute.IsEnabledAsync();
+        yield return isDistributeEnabled;
+        DistributeEnabled.isOn = isDistributeEnabled.Result;
 
         Distribute.ReleaseAvailable = (releaseDetails) => true;
         UserId.text = _customUserId;


### PR DESCRIPTION
Fixed warning in Android logs about some components were changed from non-UI thread.
Moved to #232 