### PR TITLE
Fix for Unity 5.6 compatibility

### DIFF
--- a/Assets/Puppet/Editor/BuildPuppet.cs
+++ b/Assets/Puppet/Editor/BuildPuppet.cs
@@ -82,7 +82,9 @@ public class BuildPuppet
     public static void BuildPuppetSceneWsaNetXaml()
     {
         EditorUserBuildSettings.wsaUWPBuildType = WSAUWPBuildType.XAML;
+#if !UNITY_5
         PlayerSettings.scriptingRuntimeVersion = ScriptingRuntimeVersion.Legacy;
+#endif
         PlayerSettings.SetApiCompatibilityLevel(BuildTargetGroup.WSA, ApiCompatibilityLevel.NET_4_6);
         BuildPuppetScene(BuildTarget.WSAPlayer, BuildTargetGroup.WSA, ScriptingImplementation.WinRTDotNET, "WSANetBuildXaml");
     }
@@ -90,7 +92,9 @@ public class BuildPuppet
     public static void BuildPuppetSceneWsaIl2CPPXaml()
     {
         EditorUserBuildSettings.wsaUWPBuildType = WSAUWPBuildType.XAML;
+#if !UNITY_5
         PlayerSettings.scriptingRuntimeVersion = ScriptingRuntimeVersion.Legacy;
+#endif
         PlayerSettings.SetApiCompatibilityLevel(BuildTargetGroup.WSA, ApiCompatibilityLevel.NET_4_6);
         BuildPuppetScene(BuildTarget.WSAPlayer, BuildTargetGroup.WSA, ScriptingImplementation.IL2CPP, "WSAIL2CPPBuildXaml");
     }
@@ -99,7 +103,9 @@ public class BuildPuppet
     {
         EditorUserBuildSettings.wsaUWPBuildType = WSAUWPBuildType.D3D;
         PlayerSettings.WSA.compilationOverrides = PlayerSettings.WSACompilationOverrides.UseNetCore;
+#if !UNITY_5
         PlayerSettings.scriptingRuntimeVersion = ScriptingRuntimeVersion.Legacy;
+#endif
         PlayerSettings.SetApiCompatibilityLevel(BuildTargetGroup.WSA, ApiCompatibilityLevel.NET_4_6);
         BuildPuppetScene(BuildTarget.WSAPlayer, BuildTargetGroup.WSA, ScriptingImplementation.WinRTDotNET, "WSANetBuildD3D");
     }
@@ -107,7 +113,9 @@ public class BuildPuppet
     public static void BuildPuppetSceneWsaIl2CPPD3D()
     {
         EditorUserBuildSettings.wsaUWPBuildType = WSAUWPBuildType.D3D;
+#if !UNITY_5
         PlayerSettings.scriptingRuntimeVersion = ScriptingRuntimeVersion.Legacy;
+#endif
         PlayerSettings.SetApiCompatibilityLevel(BuildTargetGroup.WSA, ApiCompatibilityLevel.NET_4_6);
         BuildPuppetScene(BuildTarget.WSAPlayer, BuildTargetGroup.WSA, ScriptingImplementation.IL2CPP, "WSAIL2CPPBuildD3D");
     }


### PR DESCRIPTION
Fixes compilation errors in Unity 5.6
`Assets/Puppet/Editor/BuildPuppet.cs(85,50): error CS0103: The name 'ScriptingRuntimeVersion' does not exist in the current context`