### PR TITLE
Fix possible nullable string inside TrackError

### DIFF
--- a/Assets/AppCenter/Plugins/iOS/Crashes/WrapperException.mm
+++ b/Assets/AppCenter/Plugins/iOS/Crashes/WrapperException.mm
@@ -2,8 +2,8 @@
 //
 // Licensed under the MIT license.
 
-#import "WrapperException.h"
 #import "NSStringHelper.h"
+#import "WrapperException.h"
 #import <Foundation/Foundation.h>
 
 MSException* appcenter_unity_exception_create()

--- a/Assets/AppCenter/Plugins/iOS/Crashes/WrapperException.mm
+++ b/Assets/AppCenter/Plugins/iOS/Crashes/WrapperException.mm
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 #import "WrapperException.h"
+#import "NSStringHelper.h"
 #import <Foundation/Foundation.h>
 
 MSException* appcenter_unity_exception_create()
@@ -22,7 +23,7 @@ void appcenter_unity_exception_set_message(MSException* exception, char* message
 
 void appcenter_unity_exception_set_stacktrace(MSException* exception, char* stacktrace)
 {
-    [exception setStackTrace:[NSString stringWithUTF8String:stacktrace]];
+    [exception setStackTrace:appcenter_unity_cstr_to_ns_string(stacktrace)];
 }
 
 void appcenter_unity_exception_set_inner_exception(MSException* exception, MSException* innerException)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # App Center SDK for Unity Change Log
 
+## Release 1.4.1
+
+* **[Fix]** Fixed iOS application crash when trying to pass exception without stack trace to `Crashes.TrackError`
+
 ## Release 1.4.0
 
 Updated native SDK versions:


### PR DESCRIPTION
When using App Center Unity SDK with iOS app, calling the method `Crashes.TrackError` like this:
`Crashes.TrackError(new Exception("error"));`
caused a runtime exception.