### PR TITLE
The value of the new UserID changes back to the value of the previous Startup mode

### DIFF
--- a/Assets/Puppet/PuppetAppCenter.cs
+++ b/Assets/Puppet/PuppetAppCenter.cs
@@ -257,6 +257,7 @@ public class PuppetAppCenter : MonoBehaviour
 
     public void OnUserIdChanged(string newUserId)
     {
+        _customUserId = newUserId;
         PlayerPrefs.SetString(UserIdKey, newUserId);
         AppCenter.SetUserId(newUserId);
     }


### PR DESCRIPTION
## Description

**Repro Steps**

1. Open an Unity Demo app
2. Enter a User ID on "Override User ID"
3. Change Startup mode and restart the App
4. Enter a new User ID on "Override User ID"
5. Then click "Analytics" tab
6. Back to App Center tab to observe if the User ID is the new User ID

## Related PRs or issues

[AB#63940](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63940)