### PR TITLE
Fixed AC state changing when switch to transmission tab

### DIFF
--- a/AppCenterDemoApp/Assets/Puppet/PuppetTransmission.cs
+++ b/AppCenterDemoApp/Assets/Puppet/PuppetTransmission.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AppCenter.Unity;
 using Microsoft.AppCenter.Unity.Analytics;
 using UnityEngine;
 using UnityEngine.UI;

--- a/AppCenterDemoApp/Assets/Puppet/PuppetTransmission.cs
+++ b/AppCenterDemoApp/Assets/Puppet/PuppetTransmission.cs
@@ -34,6 +34,7 @@ public class PuppetTransmission : MonoBehaviour
 
     private void OnEnable()
     {
+        AppCenter.StartFromLibrary(new Type[]{ AppCenter.Analytics });
         TransmissionTarget.text = _transmissionTargetToken;
         ChildTransmissionTarget.text = _childTransmissionTargetToken;
         var transmissionTarget = Analytics.GetTransmissionTarget(ResolveToken());

--- a/Assets/Puppet/PuppetTransmission.cs
+++ b/Assets/Puppet/PuppetTransmission.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AppCenter.Unity.Analytics;
+using Microsoft.AppCenter.Unity;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -39,6 +40,7 @@ public class PuppetTransmission : MonoBehaviour
 
     private void OnEnable()
     {
+        AppCenter.StartFromLibrary(new Type[]{ AppCenter.Analytics });
         TransmissionTarget.text = _parentTransmissionTargetToken;
         ChildTransmissionTarget.text = _childTransmissionTargetToken;
 


### PR DESCRIPTION
Fix "App Center is still disabled when changed startup mode to Skip, restarted and switch to Transmission tab" bug

[AB#64117](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/64120)