### PR TITLE
Feature/auth ios content provider

### DIFF
--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -437,17 +437,29 @@ public class AppCenterPostBuild : IPostprocessBuild
 
     private static void OnPostprocessInfo(PlistDocumentWrapper info, AppCenterSettings settings)
     {
-        if (settings.UseDistribute && AppCenter.Distribute != null)
+        if ((settings.UseAuth && AppCenter.Auth != null) || (settings.UseDistribute && AppCenter.Distribute != null))
         {
             // Add App Center URL sceme.
             var root = info.GetRoot();
             var urlTypes = root.GetType().GetMethod("CreateArray").Invoke(root, new object[] { "CFBundleURLTypes" });
-            var urlType = urlTypes.GetType().GetMethod("AddDict").Invoke(urlTypes, null);
-            var setStringMethod = urlType.GetType().GetMethod("SetString");
-            setStringMethod.Invoke(urlType, new object[] { "CFBundleTypeRole", "None" });
-            setStringMethod.Invoke(urlType, new object[] { "CFBundleURLName", ApplicationIdHelper.GetApplicationId() });
-            var urlSchemes = urlType.GetType().GetMethod("CreateArray").Invoke(urlType, new[] { "CFBundleURLSchemes" });
-            urlSchemes.GetType().GetMethod("AddString").Invoke(urlSchemes, new[] { "appcenter-" + settings.iOSAppSecret });
+            if(settings.UseAuth && AppCenter.Auth != null)
+            {
+                var urlType = urlTypes.GetType().GetMethod("AddDict").Invoke(urlTypes, null);
+                var setStringMethod = urlType.GetType().GetMethod("SetString");
+                setStringMethod.Invoke(urlType, new object[] { "CFBundleTypeRole", "Editor" });
+                setStringMethod.Invoke(urlType, new object[] { "CFBundleURLName", "$(PRODUCT_BUNDLE_IDENTIFIER)" });
+                var urlSchemes = urlType.GetType().GetMethod("CreateArray").Invoke(urlType, new[] { "CFBundleURLSchemes" });
+                urlSchemes.GetType().GetMethod("AddString").Invoke(urlSchemes, new[] { "msal" + settings.iOSAppSecret });
+            }
+            if (settings.UseDistribute && AppCenter.Distribute != null)
+            {
+                var urlType = urlTypes.GetType().GetMethod("AddDict").Invoke(urlTypes, null);
+                var setStringMethod = urlType.GetType().GetMethod("SetString");
+                setStringMethod.Invoke(urlType, new object[] { "CFBundleTypeRole", "None" });
+                setStringMethod.Invoke(urlType, new object[] { "CFBundleURLName", ApplicationIdHelper.GetApplicationId() });
+                var urlSchemes = urlType.GetType().GetMethod("CreateArray").Invoke(urlType, new[] { "CFBundleURLSchemes" });
+                urlSchemes.GetType().GetMethod("AddString").Invoke(urlSchemes, new[] { "appcenter-" + settings.iOSAppSecret });
+            }
         }
     }
 

--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -465,6 +465,10 @@ public class AppCenterPostBuild : IPostprocessBuild
 
     private static void OnPostprocessCapabilities(ProjectCapabilityManagerWrapper capabilityManager, AppCenterSettings settings)
     {
+        if (settings.UseAuth && AppCenter.Auth != null)
+        {
+            capabilityManager.AddAuthKeychainSharing();
+        }
         if (settings.UsePush && AppCenter.Push != null)
         {
             capabilityManager.AddPushNotifications();

--- a/Assets/AppCenter/Editor/AppCenterSettingsMakerIos.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsMakerIos.cs
@@ -18,8 +18,8 @@ public class AppCenterSettingsMakerIos : IAppCenterSettingsMaker
     private const string UsePushToken = "APPCENTER_UNITY_USE_PUSH";
     private const string UseAnalyticsToken = "APPCENTER_UNITY_USE_ANALYTICS";
     private const string UseAuthToken = "APPCENTER_UNITY_USE_AUTH";
-    private const string AuthConfigUrlSearchText = "auth-custom-config-url";
-    private const string AuthConfigUrlToken = "APPCENTER_UNITY_USE_AUTH_CUSTOM_CONFIG_URL";
+    private const string AuthConfigUrlSearchText = "custom-auth-config-url";
+    private const string AuthConfigUrlToken = "APPCENTER_UNITY_USE_CUSTOM_AUTH_CONFIG_URL";
     private const string UseDistributeToken = "APPCENTER_UNITY_USE_DISTRIBUTE";
     private const string ApiUrlSearchText = "custom-api-url";
     private const string ApiUrlToken = "APPCENTER_UNITY_USE_CUSTOM_API_URL";

--- a/Assets/AppCenter/Editor/ProjectCapabilityManagerWrapper.cs
+++ b/Assets/AppCenter/Editor/ProjectCapabilityManagerWrapper.cs
@@ -33,7 +33,7 @@ public class ProjectCapabilityManagerWrapper
 
     public void AddAuthKeychainSharing()
     {
-        string[] accessGroups = { "com.microsoft.adalcache" };
+        string[] accessGroups = { "$(AppIdentifierPrefix)com.microsoft.adalcache" };
         ProjectCapabilityManagerType.GetMethod("AddKeychainSharing").Invoke(_capabilityManager, new object[] { accessGroups });
     }
 

--- a/Assets/AppCenter/Editor/ProjectCapabilityManagerWrapper.cs
+++ b/Assets/AppCenter/Editor/ProjectCapabilityManagerWrapper.cs
@@ -31,6 +31,12 @@ public class ProjectCapabilityManagerWrapper
         ProjectCapabilityManagerType.GetMethod("AddBackgroundModes").Invoke(_capabilityManager, new object[] { remoteNotifEnum });
     }
 
+    public void AddAuthKeychainSharing()
+    {
+        string[] accessGroups = { "com.microsoft.adalcache" };
+        ProjectCapabilityManagerType.GetMethod("AddKeychainSharing").Invoke(_capabilityManager, new object[] { accessGroups });
+    }
+
     public static bool ProjectCapabilityManagerIsAvailable
     {
         get

--- a/Assets/AppCenter/Plugins/iOS/Core/AppCenterStarter.original
+++ b/Assets/AppCenter/Plugins/iOS/Core/AppCenterStarter.original
@@ -20,6 +20,10 @@
 @import AppCenterAnalytics;
 #endif
 
+#ifdef APPCENTER_UNITY_USE_AUTH
+@import AppCenterAuth;
+#endif
+
 #ifdef APPCENTER_UNITY_USE_DISTRIBUTE
 @import AppCenterDistribute;
 #import "../Distribute/DistributeDelegate.h"
@@ -38,6 +42,7 @@ enum StartupMode {
 static NSString *const kMSAppSecret = @"appcenter-app-secret";
 static NSString *const kMSTargetToken = @"appcenter-transmission-target-token";
 static NSString *const kMSCustomLogUrl = @"custom-log-url";
+static NSString *const kMSCustomAuthConfigUrl = @"custom-auth-config-url";
 static NSString *const kMSCustomApiUrl = @"custom-api-url";
 static NSString *const kMSCustomInstallUrl = @"custom-install-url";
 static NSString *const kMSStartTargetKey = @"MSAppCenterStartTargetUnityKey";
@@ -87,6 +92,14 @@ static const int kMSStartupType = 0 /*STARTUP_TYPE*/;
 #ifdef APPCENTER_UNITY_USE_ANALYTICS
   [classes addObject:MSAnalytics.class];
 #endif
+
+#ifdef APPCENTER_UNITY_USE_AUTH
+  [classes addObject:MSAuth.class];
+#endif
+
+#ifdef APPCENTER_UNITY_USE_CUSTOM_AUTH_CONFIG_URL
+  [MSAuth setConfigUrl:kMSCustomAuthConfigUrl];
+#endif // APPCENTER_UNITY_USE_CUSTOM_AUTH_CONFIG_URL
 
 #ifdef APPCENTER_UNITY_USE_PUSH
   [MSPush setDelegate:[UnityPushDelegate sharedInstance]];


### PR DESCRIPTION
Start Auth service on iOS platform. Add script to modify project Info.plist and add keychain sharing capability (followed the Auth iOS docs).

[AB#66437](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/66437)