### PR TITLE
[Auth] Fix merger script

### DIFF
--- a/Assets/AppCenter/Editor/CreateManifest.cs
+++ b/Assets/AppCenter/Editor/CreateManifest.cs
@@ -143,22 +143,19 @@ public class CreateManifest
             Directory.Delete(loaderFolder, true);
             return;
         }
-        var activityElement = new XElement("activity");
-        var activityElements = applicationElements[0].Elements().Where(element => element.Name.LocalName == "activity").ToList();
 
-        if (activityElements.Count == 1)
+        var activityElement = applicationElements[0].Elements().FirstOrDefault(element => element.Name.LocalName == "activity");
+        if (activityElement == null)
         {
-            activityElement = activityElements[0];
+            activityElement = new XElement("activity");
         }
-        var intentElement = new XElement("intent-filter");
-        var intentElements = activityElement.Elements().Where(element => element.Name.LocalName == "intent-filter").ToList();
+        var intentElement = activityElement.Elements().FirstOrDefault(element => element.Name.LocalName == "intent-filter");
+        if (intentElement == null)
+        {
+            intentElement = new XElement("intent-filter");
+        }
 
-        if (intentElements.Count == 1)
-        {
-            intentElement = intentElements[0];
-        }
         XNamespace ns = "http://schemas.android.com/apk/res/android";
-
         activityElement.SetAttributeValue(ns + "name", "com.microsoft.identity.client.BrowserTabActivity");
         var actionElement = new XElement("action");
         actionElement.SetAttributeValue(ns + "name", "android.intent.action.VIEW");

--- a/Assets/AppCenter/Editor/CreateManifest.cs
+++ b/Assets/AppCenter/Editor/CreateManifest.cs
@@ -143,60 +143,34 @@ public class CreateManifest
             Directory.Delete(loaderFolder, true);
             return;
         }
-        bool activityElementIsNew = false;
-        var activityElement = applicationElements[0].Elements().FirstOrDefault(element => element.Name.LocalName == "activity");
-        if (activityElement == null)
-        {
-            activityElementIsNew = true;
-            activityElement = new XElement("activity");
-        }
-        bool intentElementIsNew = false;
-        var intentElement = activityElement.Elements().FirstOrDefault(element => element.Name.LocalName == "intent-filter");
-        if (intentElement == null)
-        {
-            intentElementIsNew = true;
-            intentElement = new XElement("intent-filter");
-        }
+        var activityElementOld = applicationElements[0].Elements().FirstOrDefault(element => element.Name.LocalName == "activity");
+       
 
+        var intentElement = new XElement("intent-filter");
         XNamespace ns = "http://schemas.android.com/apk/res/android";
+        var activityElement = new XElement("activity");
         activityElement.SetAttributeValue(ns + "name", "com.microsoft.identity.client.BrowserTabActivity");
-        var actionElement = intentElement.Elements().FirstOrDefault(element => element.Name.LocalName == "intent-filter");
-        bool actionElementIsNew = false;
-        if (actionElement == null)
-        {
-            actionElementIsNew = true;
-            actionElement = new XElement("action");
-        }
+        var actionElement = new XElement("action");
         actionElement.SetAttributeValue(ns + "name", "android.intent.action.VIEW");
         var categoryElement1 = new XElement("category");
         categoryElement1.SetAttributeValue(ns + "name", "android.intent.category.DEFAULT");
         var categoryElement2 = new XElement("category");
         categoryElement2.SetAttributeValue(ns + "name", "android.intent.category.BROWSABLE");
-        bool dataElementIsNew = false;
-        var dataElement = intentElement.Elements().FirstOrDefault(element => element.Name.LocalName == "data");
-        if (dataElement == null)
-        {
-            dataElementIsNew = true;
-            dataElement = new XElement("data");
-        }
+        var dataElement = new XElement("data");
         dataElement.SetAttributeValue(ns + "host", "auth");
         dataElement.SetAttributeValue(ns + "scheme", "msal" + settings.AndroidAppSecret);
 
-        if (actionElementIsNew)
-        {
-            intentElement.Add(actionElement);
-        }
+        intentElement.Add(actionElement);
         intentElement.Add(categoryElement1);
         intentElement.Add(categoryElement2);
-        if (dataElementIsNew)
+        intentElement.Add(dataElement);
+        activityElement.Add(intentElement);
+
+        if (activityElementOld != null)
         {
-            intentElement.Add(dataElement);
+            activityElementOld.ReplaceWith(activityElement);
         }
-        if (intentElementIsNew)
-        {
-            activityElement.Add(intentElement);
-        }
-        if (activityElementIsNew)
+        else
         {
             applicationElements[0].Add(activityElement);
         }

--- a/Assets/AppCenter/Editor/CreateManifest.cs
+++ b/Assets/AppCenter/Editor/CreateManifest.cs
@@ -143,18 +143,22 @@ public class CreateManifest
             Directory.Delete(loaderFolder, true);
             return;
         }
+        var activityElement = new XElement("activity");
         var activityElements = applicationElements[0].Elements().Where(element => element.Name.LocalName == "activity").ToList();
 
-        // Delete the unzipped folder if the activity element already exists in the AndroidManifest.xml file
         if (activityElements.Count == 1)
         {
-            Directory.Delete(loaderFolder, true);
-            return;
+            activityElement = activityElements[0];
         }
-
         var intentElement = new XElement("intent-filter");
+        var intentElements = activityElement.Elements().Where(element => element.Name.LocalName == "intent-filter").ToList();
+
+        if (intentElements.Count == 1)
+        {
+            intentElement = intentElements[0];
+        }
         XNamespace ns = "http://schemas.android.com/apk/res/android";
-        var activityElement = new XElement("activity");
+
         activityElement.SetAttributeValue(ns + "name", "com.microsoft.identity.client.BrowserTabActivity");
         var actionElement = new XElement("action");
         actionElement.SetAttributeValue(ns + "name", "android.intent.action.VIEW");

--- a/Assets/AppCenter/Editor/CreateManifest.cs
+++ b/Assets/AppCenter/Editor/CreateManifest.cs
@@ -143,36 +143,63 @@ public class CreateManifest
             Directory.Delete(loaderFolder, true);
             return;
         }
-
+        bool activityElementIsNew = false;
         var activityElement = applicationElements[0].Elements().FirstOrDefault(element => element.Name.LocalName == "activity");
         if (activityElement == null)
         {
+            activityElementIsNew = true;
             activityElement = new XElement("activity");
         }
+        bool intentElementIsNew = false;
         var intentElement = activityElement.Elements().FirstOrDefault(element => element.Name.LocalName == "intent-filter");
         if (intentElement == null)
         {
+            intentElementIsNew = true;
             intentElement = new XElement("intent-filter");
         }
 
         XNamespace ns = "http://schemas.android.com/apk/res/android";
         activityElement.SetAttributeValue(ns + "name", "com.microsoft.identity.client.BrowserTabActivity");
-        var actionElement = new XElement("action");
+        var actionElement = intentElement.Elements().FirstOrDefault(element => element.Name.LocalName == "intent-filter");
+        bool actionElementIsNew = false;
+        if (actionElement == null)
+        {
+            actionElementIsNew = true;
+            actionElement = new XElement("action");
+        }
         actionElement.SetAttributeValue(ns + "name", "android.intent.action.VIEW");
         var categoryElement1 = new XElement("category");
         categoryElement1.SetAttributeValue(ns + "name", "android.intent.category.DEFAULT");
         var categoryElement2 = new XElement("category");
         categoryElement2.SetAttributeValue(ns + "name", "android.intent.category.BROWSABLE");
-        var dataElement = new XElement("data");
+        bool dataElementIsNew = false;
+        var dataElement = intentElement.Elements().FirstOrDefault(element => element.Name.LocalName == "data");
+        if (dataElement == null)
+        {
+            dataElementIsNew = true;
+            dataElement = new XElement("data");
+        }
         dataElement.SetAttributeValue(ns + "host", "auth");
         dataElement.SetAttributeValue(ns + "scheme", "msal" + settings.AndroidAppSecret);
 
-        intentElement.Add(actionElement);
+        if (actionElementIsNew)
+        {
+            intentElement.Add(actionElement);
+        }
         intentElement.Add(categoryElement1);
         intentElement.Add(categoryElement2);
-        intentElement.Add(dataElement);
-        activityElement.Add(intentElement);
-        applicationElements[0].Add(activityElement);
+        if (dataElementIsNew)
+        {
+            intentElement.Add(dataElement);
+        }
+        if (intentElementIsNew)
+        {
+            activityElement.Add(intentElement);
+        }
+        if (activityElementIsNew)
+        {
+            applicationElements[0].Add(activityElement);
+        }
         xmlFile.Save(manifestPath);
 
         // Delete the AndroidManifest.xml.meta file if generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Updated native SDK versions:
 
 ### App Center Auth
 
-* **[Fix]** Fix Auth was incorrectly caching the old app secret in the manifest if it wqas changed.
+* **[Fix]** Fix Auth was incorrectly caching the old app secret in the manifest if it was changed.
 
 ### App Center Crashes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Updated native SDK versions:
 * **[Fix]** Fix `AppCenterStarter.m` was not included in the first build.
 * **[Fix]** Fix Unity 2019.3 iOS build.
 
+### App Center Auth
+
+* **[Fix]** Fix Auth was incorrectly caching the old app secret in the manifest if it wqas changed.
+
 ### App Center Crashes
 
 #### Android


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [X] Has `CHANGELOG.md` been updated?
* [X] Are the files formatted correctly?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

During Auth manifest merging process, if the old `activity` tag with an old app secret value existed in `appcenter-loader` manifest, it was used all the time despite the secret has changed.

## Misc

[AB#69746](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/69746)
