### PR TITLE
CrashesDelegate warnings disabled

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Blank/CrashesDelegate.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Blank/CrashesDelegate.cs
@@ -15,7 +15,9 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         public static event Crashes.FailedToSendErrorReportHandler FailedToSendErrorReport;
 #pragma warning restore 0067
 
+#pragma warning disable 0649
         internal static Crashes.GetErrorAttachmentsHandler GetErrorAttachmentsHandler;
+#pragma warning restore 0649
 
         public static void SetDelegate()
         {

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/UWP/CrashesDelegate.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/UWP/CrashesDelegate.cs
@@ -13,10 +13,11 @@ namespace Microsoft.AppCenter.Unity.Crashes.Internal
         public static event Crashes.SentErrorReportHandler SentErrorReport;
 
         public static event Crashes.FailedToSendErrorReportHandler FailedToSendErrorReport;
-
-        internal static Crashes.GetErrorAttachmentsHandler GetErrorAttachmentsHandler;
-
 #pragma warning restore 0067
+
+#pragma warning disable 0649
+        internal static Crashes.GetErrorAttachmentsHandler GetErrorAttachmentsHandler;
+#pragma warning restore 0649
 
         public static void SetDelegate()
         {


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Unity warnings in 'CrashesDelegate' were disabled.

## Misc

[AB#71180](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/71180)