### PR TITLE
Fix child transmission target can't inherit the property on parent transmission

### DIFF
--- a/AppCenterDemoApp/Assets/Puppet/PuppetTransmission.cs
+++ b/AppCenterDemoApp/Assets/Puppet/PuppetTransmission.cs
@@ -450,17 +450,19 @@ public class PuppetTransmission : MonoBehaviour
             else
             {
                 var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
-                if (properties != null) {
-                  foreach (var property in properties)
-                  {
-                      propertyConfigurator.SetEventProperty(property.Key, property.Value);
-                  }
+                if (properties != null)
+                {
+                    foreach (var property in properties)
+                    {
+                        propertyConfigurator.SetEventProperty(property.Key, property.Value);
+                    }
                 }
-                if (propertiesParents != null) {
-                  foreach (var property in propertiesParents)
-                  {
-                      propertyConfigurator.SetEventProperty(property.Key, property.Value);
-                  }
+                if (propertiesParents != null)
+                {
+                    foreach (var property in propertiesParents)
+                    {
+                        propertyConfigurator.SetEventProperty(property.Key, property.Value);
+                    }
                 }
                 propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
                 propertyConfigurator.RemoveEventProperty("extraEventProperty");
@@ -503,10 +505,12 @@ public class PuppetTransmission : MonoBehaviour
             else
             {
                 var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
-                if (properties != null) {
+                if (properties != null)
+                {
                     PropertiesHelper.AddPropertiesToPropertyConfigurator(EventChildPropertiesList, propertyConfigurator);
                 }
-                if (propertiesParents != null) {
+                if (propertiesParents != null)
+                {
                     PropertiesHelper.AddPropertiesToPropertyConfigurator(EventParentPropertiesList, propertyConfigurator);
                 }
                 propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");

--- a/AppCenterDemoApp/Assets/Puppet/PuppetTransmission.cs
+++ b/AppCenterDemoApp/Assets/Puppet/PuppetTransmission.cs
@@ -431,7 +431,11 @@ public class PuppetTransmission : MonoBehaviour
         {
             OverrideChildProperties(transmissionTarget);
             var properties = PropertiesHelper.GetStringProperties(EventChildPropertiesList);
-            if (properties == null)
+            var propertiesParents = PropertiesHelper.GetStringProperties(EventParentPropertiesList);
+            List<Dictionary<string, string>> propertylist = new List<Dictionary<string, string>>();
+            propertylist.Add(properties);
+            propertylist.Add(propertiesParents);
+            if (propertylist.Count == 0)
             {
                 if (_isCritical)
                 {
@@ -446,9 +450,17 @@ public class PuppetTransmission : MonoBehaviour
             else
             {
                 var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
-                foreach (var property in properties)
-                {
-                    propertyConfigurator.SetEventProperty(property.Key, property.Value);
+                if (properties != null) {
+                  foreach (var property in properties)
+                  {
+                      propertyConfigurator.SetEventProperty(property.Key, property.Value);
+                  }
+                }
+                if (propertiesParents != null) {
+                  foreach (var property in propertiesParents)
+                  {
+                      propertyConfigurator.SetEventProperty(property.Key, property.Value);
+                  }
                 }
                 propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
                 propertyConfigurator.RemoveEventProperty("extraEventProperty");
@@ -472,7 +484,11 @@ public class PuppetTransmission : MonoBehaviour
         {
             OverrideChildProperties(transmissionTarget);
             var properties = PropertiesHelper.GetTypedProperties(EventChildPropertiesList);
-            if (properties == null)
+            var propertiesParents = PropertiesHelper.GetTypedProperties(EventParentPropertiesList);
+            List<EventProperties> propertylist = new List<EventProperties>();
+            propertylist.Add(properties);
+            propertylist.Add(propertiesParents);
+            if (propertylist.Count == 0)
             {
                 if (_isCritical)
                 {
@@ -487,7 +503,12 @@ public class PuppetTransmission : MonoBehaviour
             else
             {
                 var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
-                PropertiesHelper.AddPropertiesToPropertyConfigurator(EventChildPropertiesList, propertyConfigurator);
+                if (properties != null) {
+                    PropertiesHelper.AddPropertiesToPropertyConfigurator(EventChildPropertiesList, propertyConfigurator);
+                }
+                if (propertiesParents != null) {
+                    PropertiesHelper.AddPropertiesToPropertyConfigurator(EventParentPropertiesList, propertyConfigurator);
+                }
                 propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
                 propertyConfigurator.RemoveEventProperty("extraEventProperty");
                 if (_isCritical)


### PR DESCRIPTION
…ansmission target

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Open Unity Demo app
Select any Startup mode and restart demo app
Click Transmission target enter Event Name
Click Add Property button to add property "A" for Parent target
Then click Add Property button to add property "B" for Child target
Observe the result on Aria portal if the property "A" can be inherited to Child target

## Related PRs or issues

https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/69752

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
