### PR TITLE
When AppCenter directory is not in "Assets" Unity can't build

### DIFF
--- a/AppCenterDemoApp/Assets/Puppet/Editor/BuildPuppet.cs
+++ b/AppCenterDemoApp/Assets/Puppet/Editor/BuildPuppet.cs
@@ -12,6 +12,7 @@ using System.Linq;
 public class BuildPuppet
 {
     private static readonly string BuildFolder = "CAKE_SCRIPT_TEMPPuppetBuilds";
+    private static readonly string AssetsFolder = "Assets";
     private static readonly string AppIdentifier = "com.microsoft.appcenter.unity.puppet";
 
     static BuildPuppet()
@@ -109,7 +110,7 @@ public class BuildPuppet
     private static void BuildPuppetScene(BuildTarget target, BuildTargetGroup targetGroup, ScriptingImplementation scriptingImplementation, string outputPath)
     {
         PlayerSettings.SetScriptingBackend(targetGroup, scriptingImplementation);
-        string[] puppetScene = { AppCenterSettingsContext.AppCenterPath + "/Puppet/PuppetScene.unity" };
+        string[] puppetScene = { AssetsFolder + "/Puppet/PuppetScene.unity" };
         var options = new BuildPlayerOptions
         {
             scenes = puppetScene,
@@ -126,12 +127,12 @@ public class BuildPuppet
     // placeholders for keys, not actual keys.
     private static void CreateGoogleServicesJsonIfNotPresent()
     {
-        var actualFile = "Assets/Puppet/Editor/google-services.json";
+        var actualFile = AssetsFolder + "/Puppet/Editor/google-services.json";
         if (File.Exists(actualFile))
         {
             return;
         }
-        var placeholderFile = "Assets/Puppet/Editor/google-services-placeholder.json";
+        var placeholderFile = AssetsFolder + "Assets/Puppet/Editor/google-services-placeholder.json";
         if (!File.Exists(placeholderFile))
         {
             Debug.Log("Could not find google services placeholder.");

--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -143,7 +143,7 @@ public class AppCenterPostBuild : IPostprocessBuild
             LogInjectFailed(appFileName);
             return;
         }
-        var appAdditionsFolder = AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/WSA/Push/AppAdditions";
+        var appAdditionsFolder = AppCenterSettingsContext.AppCenterPath + "/Plugins/WSA/Push/AppAdditions";
         var commentText = "App Center Push code:";
         var codeToInsert = Environment.NewLine + "            // " + commentText + Environment.NewLine
             + File.ReadAllText(Path.Combine(appAdditionsFolder, codeToInsertFileName));
@@ -290,7 +290,7 @@ public class AppCenterPostBuild : IPostprocessBuild
 
     public static void ProcessUwpIl2CppDependencies()
     {
-        var binaries = AssetDatabase.FindAssets("*", new[] { AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/WSA/IL2CPP" });
+        var binaries = AssetDatabase.FindAssets("*", new[] { AppCenterSettingsContext.AppCenterPath + "/Plugins/WSA/IL2CPP" });
         foreach (var guid in binaries)
         {
             var assetPath = AssetDatabase.GUIDToAssetPath(guid);

--- a/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
@@ -4,26 +4,25 @@
 using UnityEngine;
 using UnityEditor;
 using System.IO;
-using System.Reflection;
 using System;
-using System.Runtime.CompilerServices;
 
 public class AppCenterSettingsContext : ScriptableObject
 {
-	private static readonly string SettingsPath = AppCenterPath + "/AppCenterSettings.asset";
+    private static readonly string SettingsPath = AppCenterPath + "/AppCenterSettings.asset";
     private static readonly string AdvancedSettingsPath = AppCenterPath + "/AppCenterSettingsAdvanced.asset";
     private static AppCenterSettingsContext Instance;
 
     public static AppCenterSettingsContext GetInstance()
     {
-        if(Instance == null)
+        if (Instance == null)
         {
             Instance = new AppCenterSettingsContext();
         }
         return Instance;
     }
 
-    private AppCenterSettingsContext() {
+    private AppCenterSettingsContext()
+    {
     }
 
     public static string AppCenterPath
@@ -55,7 +54,7 @@ public class AppCenterSettingsContext : ScriptableObject
         get
         {
             // No need to lock because this can only be accessed from the main thread.
-            return AssetDatabase.LoadAssetAtPath<AppCenterSettingsAdvanced>(AdvancedSettingsPath);      
+            return AssetDatabase.LoadAssetAtPath<AppCenterSettingsAdvanced>(AdvancedSettingsPath);
         }
     }
 
@@ -69,7 +68,7 @@ public class AppCenterSettingsContext : ScriptableObject
     }
 
     public static AppCenterSettingsAdvanced CreateSettingsInstanceAdvanced()
-    { 
+    {
         var instance = AssetDatabase.LoadAssetAtPath<AppCenterSettingsAdvanced>(AdvancedSettingsPath);
         if (instance == null)
         {

--- a/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
@@ -3,29 +3,23 @@
 
 using UnityEngine;
 using UnityEditor;
-using System.IO;
 using System;
+using System.Linq;
 
 public class AppCenterSettingsContext : ScriptableObject
 {
+    private static string appCenterPath;
     private static readonly string SettingsPath = AppCenterPath + "/AppCenterSettings.asset";
     private static readonly string AdvancedSettingsPath = AppCenterPath + "/AppCenterSettingsAdvanced.asset";
-    private static AppCenterSettingsContext Instance;
-
-    public static AppCenterSettingsContext GetInstance()
-    {
-        if (Instance == null)
-        {
-            Instance = CreateInstance<AppCenterSettingsContext>();
-        }
-        return Instance;
-    }
-
     public static string AppCenterPath
     {
         get
         {
-            return GetInstance().GetAppCenterPath();
+            if (string.IsNullOrEmpty(appCenterPath))
+            {
+                appCenterPath = FindSubfolderPath("Assets", "AppCenter");
+            }
+            return appCenterPath;
         }
     }
 
@@ -54,13 +48,24 @@ public class AppCenterSettingsContext : ScriptableObject
         }
     }
 
-    public string GetAppCenterPath()
+    private static string FindSubfolderPath(string parentFolder, string searchFolder)
     {
-        var script = MonoScript.FromScriptableObject(this);
-        var pathScript = AssetDatabase.GetAssetPath(script);
-        var lastAppCenterIndex = pathScript.LastIndexOf("Editor", StringComparison.Ordinal);
-        var directoryAppCenter = pathScript.Remove(lastAppCenterIndex).TrimEnd(Path.DirectorySeparatorChar);
-        return directoryAppCenter;
+        string[] folders = AssetDatabase.GetSubFolders(parentFolder);
+        string resultFolder = folders.FirstOrDefault(folder => folder.EndsWith(searchFolder, StringComparison.InvariantCulture));
+        if (string.IsNullOrEmpty(resultFolder) && folders.Length > 0)
+        {
+            string temp;
+            for (int i = 0; i < folders.Length; i++)
+            {
+                temp = FindSubfolderPath(folders[i], searchFolder);
+                if (!string.IsNullOrEmpty(temp))
+                {
+                    return temp;
+                }
+
+            }
+        }
+        return resultFolder;
     }
 
     public static AppCenterSettingsAdvanced CreateSettingsInstanceAdvanced()

--- a/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
@@ -62,7 +62,6 @@ public class AppCenterSettingsContext : ScriptableObject
                 {
                     return temp;
                 }
-
             }
         }
         return resultFolder;
@@ -84,5 +83,4 @@ public class AppCenterSettingsContext : ScriptableObject
     {
         AssetDatabase.DeleteAsset(AdvancedSettingsPath);
     }
-
 }

--- a/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
@@ -3,12 +3,36 @@
 
 using UnityEngine;
 using UnityEditor;
+using System.IO;
+using System.Reflection;
+using System;
+using System.Runtime.CompilerServices;
 
 public class AppCenterSettingsContext : ScriptableObject
 {
-    public const string AppCenterPath = "Assets";
-    private const string SettingsPath = AppCenterPath + "/AppCenter/AppCenterSettings.asset";
-    private const string AdvancedSettingsPath = AppCenterPath + "/AppCenter/AppCenterSettingsAdvanced.asset";
+	private static readonly string SettingsPath = AppCenterPath + "/AppCenterSettings.asset";
+    private static readonly string AdvancedSettingsPath = AppCenterPath + "/AppCenterSettingsAdvanced.asset";
+    private static AppCenterSettingsContext Instance;
+
+    public static AppCenterSettingsContext GetInstance()
+    {
+        if(Instance == null)
+        {
+            Instance = new AppCenterSettingsContext();
+        }
+        return Instance;
+    }
+
+    private AppCenterSettingsContext() {
+    }
+
+    public static string AppCenterPath
+    {
+        get
+        {
+            return GetInstance().GetAppCenterPath();
+        }
+    }
 
     public static AppCenterSettings SettingsInstance
     {
@@ -35,8 +59,17 @@ public class AppCenterSettingsContext : ScriptableObject
         }
     }
 
-    public static AppCenterSettingsAdvanced CreateSettingsInstanceAdvanced()
+    public string GetAppCenterPath()
     {
+        var script = MonoScript.FromScriptableObject(this);
+        var pathScript = AssetDatabase.GetAssetPath(script);
+        var lastAppCenterIndex = pathScript.LastIndexOf("Editor", StringComparison.Ordinal);
+        var directoryAppCenter = pathScript.Remove(lastAppCenterIndex).TrimEnd(Path.DirectorySeparatorChar);
+        return directoryAppCenter;
+    }
+
+    public static AppCenterSettingsAdvanced CreateSettingsInstanceAdvanced()
+    { 
         var instance = AssetDatabase.LoadAssetAtPath<AppCenterSettingsAdvanced>(AdvancedSettingsPath);
         if (instance == null)
         {
@@ -51,4 +84,5 @@ public class AppCenterSettingsContext : ScriptableObject
     {
         AssetDatabase.DeleteAsset(AdvancedSettingsPath);
     }
+
 }

--- a/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
@@ -16,7 +16,7 @@ public class AppCenterSettingsContext : ScriptableObject
     {
         if (Instance == null)
         {
-            Instance = new AppCenterSettingsContext();
+            Instance = CreateInstance<AppCenterSettingsContext>();
         }
         return Instance;
     }

--- a/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
@@ -3,7 +3,7 @@
 
 using UnityEngine;
 using UnityEditor;
-using System;
+using System.IO;
 using System.Linq;
 
 public class AppCenterSettingsContext : ScriptableObject
@@ -51,7 +51,7 @@ public class AppCenterSettingsContext : ScriptableObject
     private static string FindSubfolderPath(string parentFolder, string searchFolder)
     {
         string[] folders = AssetDatabase.GetSubFolders(parentFolder);
-        string resultFolder = folders.FirstOrDefault(folder => folder.EndsWith(searchFolder, StringComparison.InvariantCulture));
+        string resultFolder = folders.FirstOrDefault(folder => (new DirectoryInfo(folder)).Name == searchFolder);
         if (string.IsNullOrEmpty(resultFolder) && folders.Length > 0)
         {
             string temp;

--- a/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsContext.cs
@@ -21,10 +21,6 @@ public class AppCenterSettingsContext : ScriptableObject
         return Instance;
     }
 
-    private AppCenterSettingsContext()
-    {
-    }
-
     public static string AppCenterPath
     {
         get

--- a/Assets/AppCenter/Editor/AppCenterSettingsMakerAndroid.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsMakerAndroid.cs
@@ -134,27 +134,27 @@ public class AppCenterSettingsMakerAndroid : IAppCenterSettingsMaker
 
     public bool IsAnalyticsAvailable()
     {
-        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-analytics-release.aar");
+        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/Android/appcenter-analytics-release.aar");
     }
 
     public bool IsAuthAvailable()
     {
-        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-auth-release.aar");
+        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/Android/appcenter-auth-release.aar");
     }
 
     public bool IsCrashesAvailable()
     {
-        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-crashes-release.aar");
+        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/Android/appcenter-crashes-release.aar");
     }
 
     public bool IsDistributeAvailable()
     {
-        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-distribute-release.aar");
+        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/Android/appcenter-distribute-release.aar");
     }
 
     public bool IsPushAvailable()
     {
-        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-push-release.aar");
+        return File.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/Android/appcenter-push-release.aar");
     }
 
     public void SetShouldEnableDistributeForDebuggableBuild()

--- a/Assets/AppCenter/Editor/AppCenterSettingsMakerIos.cs
+++ b/Assets/AppCenter/Editor/AppCenterSettingsMakerIos.cs
@@ -6,8 +6,8 @@ using UnityEditor;
 
 public class AppCenterSettingsMakerIos : IAppCenterSettingsMaker
 {
-    private const string TemplateFilePath = AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Core/AppCenterStarter.original";
-    private const string TargetFilePath = AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Core/AppCenterStarter.m";
+    private static readonly string TemplateFilePath = AppCenterSettingsContext.AppCenterPath + "/Plugins/iOS/Core/AppCenterStarter.original";
+    private static readonly string TargetFilePath = AppCenterSettingsContext.AppCenterPath + "/Plugins/iOS/Core/AppCenterStarter.m";
     private const string AppSecretSearchText = "appcenter-app-secret";
     private const string TransmissionTargetTokenSearchText = "appcenter-transmission-target-token";
     private const string LogUrlSearchText = "custom-log-url";
@@ -136,27 +136,27 @@ public class AppCenterSettingsMakerIos : IAppCenterSettingsMaker
 
     public bool IsAnalyticsAvailable()
     {
-        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Analytics");
+        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/iOS/Analytics");
     }
 
     public bool IsAuthAvailable()
     {
-        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Auth");
+        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/iOS/Auth");
     }
 
     public bool IsCrashesAvailable()
     {
-        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Crashes");
+        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/iOS/Crashes");
     }
 
     public bool IsDistributeAvailable()
     {
-        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Distribute");
+        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/iOS/Distribute");
     }
 
     public bool IsPushAvailable()
     {
-        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/iOS/Push");
+        return Directory.Exists(AppCenterSettingsContext.AppCenterPath + "/Plugins/iOS/Push");
     }
 
     public void SetShouldEnableDistributeForDebuggableBuild()

--- a/Assets/AppCenter/Editor/CreateManifest.cs
+++ b/Assets/AppCenter/Editor/CreateManifest.cs
@@ -22,7 +22,7 @@ public class CreateManifest
                 .Append("/c powershell")
                 .Append(" -File \"")
                 .Append(AppCenterSettingsContext.AppCenterPath)
-                .Append("/AppCenter/Plugins/Android/Utility/archive.ps1 \"")
+                .Append("/Plugins/Android/Utility/archive.ps1 \"")
                 .Append(" -Source ")
                 .Append(sourceFile)
                 .Append(" -Destination ")
@@ -83,7 +83,7 @@ public class CreateManifest
                 .Append("/c powershell")
                 .Append(" -File \"")
                 .Append(AppCenterSettingsContext.AppCenterPath)
-                .Append("/AppCenter/Plugins/Android/Utility/unarchive.ps1 \"")
+                .Append("/Plugins/Android/Utility/unarchive.ps1 \"")
                 .Append(" -Source ")
                 .Append(sourceFile)
                 .Append(" -Destination ")
@@ -110,7 +110,7 @@ public class CreateManifest
 
     public static void Create(AppCenterSettings settings)
     {
-        var loaderZipFile = AppCenterSettingsContext.AppCenterPath + "/AppCenter/Plugins/Android/appcenter-loader-release.aar";
+        var loaderZipFile = AppCenterSettingsContext.AppCenterPath + "/Plugins/Android/appcenter-loader-release.aar";
         var loaderFolder = "appcenter-loader-release";
         var manifestPath = "appcenter-loader-release/AndroidManifest.xml";
         var manifestMetafile = "appcenter-loader-release/AndroidManifest.xml.meta";

--- a/Assets/Puppet/Editor/BuildPuppet.cs
+++ b/Assets/Puppet/Editor/BuildPuppet.cs
@@ -12,6 +12,7 @@ using System.Linq;
 public class BuildPuppet
 {
     private static readonly string BuildFolder = "CAKE_SCRIPT_TEMPPuppetBuilds";
+    private static readonly string AssetsFolder = "Assets";
     private static readonly string AppIdentifier = "com.microsoft.appcenter.unity.puppet";
 
     static BuildPuppet()
@@ -109,7 +110,7 @@ public class BuildPuppet
     private static void BuildPuppetScene(BuildTarget target, BuildTargetGroup targetGroup, ScriptingImplementation scriptingImplementation, string outputPath)
     {
         PlayerSettings.SetScriptingBackend(targetGroup, scriptingImplementation);
-        string[] puppetScene = { AppCenterSettingsContext.AppCenterPath + "/Puppet/PuppetScene.unity" };
+        string[] puppetScene = { AssetsFolder + "/Puppet/PuppetScene.unity" };
         var options = new BuildPlayerOptions
         {
             scenes = puppetScene,
@@ -126,12 +127,12 @@ public class BuildPuppet
     // placeholders for keys, not actual keys.
     private static void CreateGoogleServicesJsonIfNotPresent()
     {
-        var actualFile = "Assets/Puppet/Editor/google-services.json";
+        var actualFile = AssetsFolder + "/Puppet/Editor/google-services.json";
         if (File.Exists(actualFile))
         {
             return;
         }
-        var placeholderFile = "Assets/Puppet/Editor/google-services-placeholder.json";
+        var placeholderFile = AssetsFolder + "/Puppet/Editor/google-services-placeholder.json";
         if (!File.Exists(placeholderFile))
         {
             Debug.Log("Could not find google services placeholder.");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Release 2.6.0 (Under development)
 
-### App Center 
+### App Center
 
 * **[Fix]** Fix Unity 2019.3 iOS build ('Use of undeclared identifier' error).
 * **[Improvement]** Detect App Center SDK location automatically.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release 2.6.0 (Under development)
 
+### App Center
+
+* **[Enhancement]** SDK now detects its location automatically.
+
 ### App Center Push
 
 * **[Bug fix]** Fix missing `NotifyPushNotificationReceived` callback if push notification is received from the background.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center
 
-* **[Enhancement]** SDK now detects its location automatically.
+* **[Improvement]** Detect App Center SDK location automatically.
 
 ### App Center Push
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] ~Are tests passing locally?~
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Related PRs or issues

[AB#69372](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/69372)

https://github.com/microsoft/appcenter-sdk-unity/issues/321
