### PR TITLE
Use of undeclared identifier error fixed.

### DIFF
--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -433,7 +433,11 @@ public class AppCenterPostBuild : IPostprocessBuild
         // Need to add "-lsqlite3" linker flag to "Other linker flags" due to
         // SQLite dependency.
         project.AddBuildProperty("OTHER_LDFLAGS", "-lsqlite3");
+#if UNITY_2019_3_OR_NEWER
+        project.AddBuildProperty("CLANG_ENABLE_MODULES", "YES", true);
+#else
         project.AddBuildProperty("CLANG_ENABLE_MODULES", "YES");
+#endif
         project.AddBuildProperty("OTHER_LDFLAGS", "-weak_framework AuthenticationServices");
         project.AddBuildProperty("OTHER_LDFLAGS", "-framework WebKit");
     }

--- a/Assets/AppCenter/Editor/PBXProjectWrapper.cs
+++ b/Assets/AppCenter/Editor/PBXProjectWrapper.cs
@@ -74,12 +74,22 @@ public class PBXProjectWrapper
         PBXProjectType.GetMethod("WriteToFile").Invoke(_pbxProject, new[] { _projectPath });
     }
 
+#if UNITY_2019_3_OR_NEWER
+    public void AddBuildProperty(string name, string value, bool toFrameworkTarget = false)
+#else
     public void AddBuildProperty(string name, string value)
+#endif
     {
         object targetGuid;
 #if UNITY_2019_3_OR_NEWER
         targetGuid = PBXProjectType.GetMethod("GetUnityMainTargetGuid")
                                        .Invoke(_pbxProject, null);
+        if (toFrameworkTarget)
+        {
+            object frameworkTarget = PBXProjectType.GetMethod("GetUnityFrameworkTargetGuid").Invoke(_pbxProject, null);
+            PBXProjectType.GetMethod("AddBuildProperty", new[] { typeof(string), typeof(string), typeof(string) })
+                          .Invoke(_pbxProject, new[] { frameworkTarget, name, value });
+        }
 #else
         var targetName = GetUnityTargetName();
         targetGuid = PBXProjectType.GetMethod("TargetGuidByName")

--- a/Assets/AppCenter/Plugins/iOS/Crashes/CrashesDelegate.h
+++ b/Assets/AppCenter/Plugins/iOS/Crashes/CrashesDelegate.h
@@ -4,12 +4,20 @@
 #import <AppCenterCrashes/AppCenterCrashes.h>
 #import <Foundation/Foundation.h>
 
-extern "C" void app_center_unity_crashes_set_delegate();
-extern "C" void app_center_unity_crashes_delegate_set_should_process_error_report_delegate(bool(*handler)(MSErrorReport *));
-extern "C" void app_center_unity_crashes_delegate_set_get_error_attachments_delegate(NSArray<MSErrorAttachmentLog *> *(*handler)(MSErrorReport *));
-extern "C" void app_center_unity_crashes_delegate_set_sending_error_report_delegate(void(*handler)(MSErrorReport *));
-extern "C" void app_center_unity_crashes_delegate_set_sent_error_report_delegate(void(*handler)(MSErrorReport *));
-extern "C" void app_center_unity_crashes_delegate_set_failed_to_send_error_report_delegate(void(*handler)(MSErrorReport *, NSError *));
+#if __cplusplus
+extern "C" {
+#endif
+
+void app_center_unity_crashes_set_delegate();
+void app_center_unity_crashes_delegate_set_should_process_error_report_delegate(bool(*handler)(MSErrorReport *));
+void app_center_unity_crashes_delegate_set_get_error_attachments_delegate(NSArray<MSErrorAttachmentLog *> *(*handler)(MSErrorReport *));
+void app_center_unity_crashes_delegate_set_sending_error_report_delegate(void(*handler)(MSErrorReport *));
+void app_center_unity_crashes_delegate_set_sent_error_report_delegate(void(*handler)(MSErrorReport *));
+void app_center_unity_crashes_delegate_set_failed_to_send_error_report_delegate(void(*handler)(MSErrorReport *, NSError *));
+
+#if __cplusplus
+}
+#endif
 
 @interface UnityCrashesDelegate : NSObject<MSCrashesDelegate>
 -(BOOL)crashes:(MSCrashes *)crashes shouldProcessErrorReport:(MSErrorReport *)errorReport;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release 2.6.0 (Under development)
 
+### App Center 
+
+* **[Fix]** Fix Unity 2019.3 iOS build ('Use of undeclared identifier' error).
+
 ### App Center Push
 
 * **[Bug fix]** Fix missing `NotifyPushNotificationReceived` callback if push notification is received from the background.


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Unity 2019.3 has a new 'UnityFramework' target in the Xcode project. The 'CLANG_ENABLE_MODULES' setting was set to 'YES' for the 'UnityFramework' target.

## Misc

[AB#72686](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/72686)
https://github.com/microsoft/appcenter-sdk-unity/issues/367