### PR TITLE
Mark changes as dirty when setting up Settings in AppCenterBehavior

### DIFF
--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditor.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditor.cs
@@ -15,8 +15,8 @@ public class AppCenterBehaviorEditor : Editor
         if (behaviour.Settings == null)
         {
             behaviour.Settings = AppCenterSettingsContext.SettingsInstance;
-			EditorUtility.SetDirty(behaviour);
-			EditorSceneManager.MarkSceneDirty(behaviour.gameObject.scene);
+	    EditorUtility.SetDirty(behaviour);
+	    EditorSceneManager.MarkSceneDirty(behaviour.gameObject.scene);
         }
         
         // Draw settings.

--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditor.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditor.cs
@@ -15,6 +15,8 @@ public class AppCenterBehaviorEditor : Editor
         if (behaviour.Settings == null)
         {
             behaviour.Settings = AppCenterSettingsContext.SettingsInstance;
+			EditorUtility.SetDirty(behaviour);
+			EditorSceneManager.MarkSceneDirty(behaviour.gameObject.scene);
         }
         
         // Draw settings.

--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditor.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using UnityEditor;
+using UnityEditor.SceneManagement;
 
 [CustomEditor(typeof(AppCenterBehavior))]
 public class AppCenterBehaviorEditor : Editor
@@ -15,8 +16,8 @@ public class AppCenterBehaviorEditor : Editor
         if (behaviour.Settings == null)
         {
             behaviour.Settings = AppCenterSettingsContext.SettingsInstance;
-	        EditorUtility.SetDirty(behaviour);
-	        EditorSceneManager.MarkSceneDirty(behaviour.gameObject.scene);
+            EditorUtility.SetDirty(behaviour);
+            EditorSceneManager.MarkSceneDirty(behaviour.gameObject.scene);
         }
         
         // Draw settings.

--- a/Assets/AppCenter/Editor/AppCenterBehaviorEditor.cs
+++ b/Assets/AppCenter/Editor/AppCenterBehaviorEditor.cs
@@ -15,8 +15,8 @@ public class AppCenterBehaviorEditor : Editor
         if (behaviour.Settings == null)
         {
             behaviour.Settings = AppCenterSettingsContext.SettingsInstance;
-	    EditorUtility.SetDirty(behaviour);
-	    EditorSceneManager.MarkSceneDirty(behaviour.gameObject.scene);
+	        EditorUtility.SetDirty(behaviour);
+	        EditorSceneManager.MarkSceneDirty(behaviour.gameObject.scene);
         }
         
         // Draw settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **[Fix]** Fix Unity 2019.3 iOS build ('Use of undeclared identifier' error).
 * **[Improvement]** Detect App Center SDK location automatically.
+* **[Fix]** Mark changes as dirty when setting up Settings in AppCenterBehavior.
 
 ### App Center Push
 


### PR DESCRIPTION
Fix for issue #377 - Settings not save in prefab

Things to consider before you submit the PR:

* [X] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

When AppCenterBehaviorEditor is setting up new setting file it is not marking this change as dirty so it can cause an issue where unity don't see any changes in files and not saving new object. What can cause an error.

## Related PRs or issues

issue #377 [https://github.com/microsoft/appcenter-sdk-unity/issues/377](url)

