### PR TITLE
Update play-services-resolver version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center
 
 * **[Fix]** Fix Unity 2019.3 iOS build ('Use of undeclared identifier' error).
+* **[Fix]** Fix Unity 2019.3 Android build ('Requested value X86 was not found' error).
 * **[Improvement]** Detect App Center SDK location automatically.
 * **[Fix]** Mark changes as dirty when setting up Settings in AppCenterBehavior.
 

--- a/build.cake
+++ b/build.cake
@@ -43,7 +43,7 @@ var ExternalUnityPackages = new [] {
     // Import the play-services-resolver-*.unitypackage into your plugin project <...> ensuring that you add the -gvh_disable option.
     // You must specify the -gvh_disable option in order for the Version Handler to work correctly!
     new ExternalUnityPackage("play-services-resolver-" + ExternalUnityPackage.VersionPlaceholder + ".unitypackage",
-                             "1.2.95.0",
+                             "1.2.135",
                              SdkStorageUrl + ExternalUnityPackage.NamePlaceholder,
                              "-gvh_disable")
 };


### PR DESCRIPTION
Things to consider before you submit the PR:

* [X] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fixes [Requested value X86 was not found](https://stackoverflow.com/questions/56309148/argumentexception-requested-value-x86-was-not-found/57632412#57632412) on Unity 2019.3 beta version.
Fixed by updating [PlayServicesResolver](https://github.com/googlesamples/unity-jar-resolver) to the latest version.

**Warning: in order for this PR to pass CI, we need to upload the new PlayServicesResolver version ([#1.2.135](https://github.com/googlesamples/unity-jar-resolver/releases/tag/v1.2.135)) to [mobilecenter blob](https://mobilecentersdkdev.blob.core.windows.net/sdk/).**

## Related PRs or issues

[AB#72802](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/72802)
