### PR TITLE
Crashes and Push services not started on iOS

### DIFF
--- a/Assets/AppCenter/link.xml
+++ b/Assets/AppCenter/link.xml
@@ -11,6 +11,7 @@
     <assembly fullname="Microsoft.AppCenter.Crashes" preserve="all" ignoreIfMissing="1"/>
     <assembly fullname="Microsoft.AppCenter.Push" preserve="all" ignoreIfMissing="1"/>
     <assembly fullname="SQLite-net" preserve="all" ignoreIfMissing="1"/>
+    <!-- Name 'Assembly-CSharp' could be changed through 'Assembly Definitions'. In this case we need to change full name here. -->
     <assembly fullname="Assembly-CSharp">
         <type fullname="Microsoft.AppCenter.Unity.Crashes.Crashes">
             <method name="StartCrashes"/>

--- a/Assets/AppCenter/link.xml
+++ b/Assets/AppCenter/link.xml
@@ -11,7 +11,7 @@
     <assembly fullname="Microsoft.AppCenter.Crashes" preserve="all" ignoreIfMissing="1"/>
     <assembly fullname="Microsoft.AppCenter.Push" preserve="all" ignoreIfMissing="1"/>
     <assembly fullname="SQLite-net" preserve="all" ignoreIfMissing="1"/>
-    <!-- Name 'Assembly-CSharp' could be changed through 'Assembly Definitions'. In this case we need to change full name here. -->
+    <!-- Name 'Assembly-CSharp' could be changed through 'Assembly Definitions'. In this case full name should be changed here. -->
     <assembly fullname="Assembly-CSharp">
         <type fullname="Microsoft.AppCenter.Unity.Crashes.Crashes">
             <method name="StartCrashes"/>

--- a/Assets/AppCenter/link.xml
+++ b/Assets/AppCenter/link.xml
@@ -11,4 +11,12 @@
     <assembly fullname="Microsoft.AppCenter.Crashes" preserve="all" ignoreIfMissing="1"/>
     <assembly fullname="Microsoft.AppCenter.Push" preserve="all" ignoreIfMissing="1"/>
     <assembly fullname="SQLite-net" preserve="all" ignoreIfMissing="1"/>
+    <assembly fullname="Assembly-CSharp">
+        <type fullname="Microsoft.AppCenter.Unity.Crashes.Crashes">
+            <method name="StartCrashes"/>
+        </type>
+        <type fullname="Microsoft.AppCenter.Unity.Push.Push">
+            <method name="StartPush"/>
+        </type>
+    </assembly>
 </linker>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 #### iOS
 
-* **[Fix]** Fix that Push could not be started because of `StartPush` method was stripped for a high managed stripping level.
+* **[Fix]** Fix that Push could not be started because `StartPush` method was stripped for a high managed stripping level.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 #### iOS
 
-* **[Fix]** Fix that Crashes could not be started because `StartCrashes` method was stripped for a high managed stripping level.
+* **[Fix]** Fix an issue where Crashes could not be started because `StartCrashes` method was stripped for a high managed stripping level.
 
 ### App Center Push
 
 #### iOS
 
-* **[Fix]** Fix that Push could not be started because `StartPush` method was stripped for a high managed stripping level.
+* **[Fix]** Fix an issue where Push could not be started because `StartPush` method was stripped for a high managed stripping level.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # App Center SDK for Unity Change Log
 
+## Development version
+
+### App Center Crashes
+
+#### iOS
+
+* **[Fix]** Fix that 'Crashes' could not be started because of 'StartCrashes' method was stripped for a high managed stripping level.
+
+### App Center Push
+
+#### iOS
+
+* **[Fix]** Fix that 'Push' could not be started because of 'StartPush' method was stripped for a high managed stripping level.
+
+___
+
 ## Release 2.6.0
 
 Updated native SDK versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,18 @@
 # App Center SDK for Unity Change Log
 
-## Development version
+## Version 2.6.1 (Under development)
 
 ### App Center Crashes
 
 #### iOS
 
-* **[Fix]** Fix that 'Crashes' could not be started because of 'StartCrashes' method was stripped for a high managed stripping level.
+* **[Fix]** Fix that Crashes could not be started because of `StartCrashes` method was stripped for a high managed stripping level.
 
 ### App Center Push
 
 #### iOS
 
-* **[Fix]** Fix that 'Push' could not be started because of 'StartPush' method was stripped for a high managed stripping level.
+* **[Fix]** Fix that Push could not be started because of `StartPush` method was stripped for a high managed stripping level.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### iOS
 
-* **[Fix]** Fix that Crashes could not be started because of `StartCrashes` method was stripped for a high managed stripping level.
+* **[Fix]** Fix that Crashes could not be started because `StartCrashes` method was stripped for a high managed stripping level.
 
 ### App Center Push
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Starting methods are called by reflection. When 'Managed Stripping Level' is set to 'Medium' then the starting functions code could be stripped. The information about these functions was added to the 'link.xml' file.

## Misc

[AB#74397](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/74397)
https://github.com/microsoft/appcenter-sdk-unity/issues/386