### PR TITLE
Fix child transmission target can't inherit Parent transmission target for common property

### DIFF
--- a/Assets/Puppet/PuppetTransmission.cs
+++ b/Assets/Puppet/PuppetTransmission.cs
@@ -312,7 +312,7 @@ public class PuppetTransmission : MonoBehaviour
         OnChildUserIdChanged(null);
     }
 
-    private PropertyConfigurator ApplyPropertyToString(TransmissionTarget transmissionTarget, RectTransform eventProperties)
+    private PropertyConfigurator ConfigurePropertiesToString(TransmissionTarget transmissionTarget, RectTransform eventProperties)
     {
         var properties = PropertiesHelper.GetStringProperties(eventProperties);
         var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
@@ -325,7 +325,7 @@ public class PuppetTransmission : MonoBehaviour
         return propertyConfigurator;
     }
 
-    private PropertyConfigurator ApplyPropertyToType(TransmissionTarget transmissionTarget, RectTransform eventProperties)
+    private PropertyConfigurator ConfigurePropertiesToType(TransmissionTarget transmissionTarget, RectTransform eventProperties)
     {
         var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
         PropertiesHelper.AddPropertiesToPropertyConfigurator(eventProperties, propertyConfigurator);
@@ -355,7 +355,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = ApplyPropertyToString(transmissionTarget, EventParentPropertiesList);
+                var propertyConfigurator = ConfigurePropertiesToString(transmissionTarget, EventParentPropertiesList);
                 if (_isCritical)
                 {
                     IDictionary<string, string> nullProps = null;
@@ -391,7 +391,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = ApplyPropertyToType(transmissionTarget, EventParentPropertiesList);
+                var propertyConfigurator = ConfigurePropertiesToType(transmissionTarget, EventParentPropertiesList);
                 if (_isCritical)
                 {
                     EventProperties nullProps = null;
@@ -412,7 +412,7 @@ public class PuppetTransmission : MonoBehaviour
         PropertyConfigurator parentPropertyConfigurator = null;
         if (parentTransmissionTarget != null)
         {
-            parentPropertyConfigurator = ApplyPropertyToString(parentTransmissionTarget, EventParentPropertiesList);
+            parentPropertyConfigurator = ConfigurePropertiesToString(parentTransmissionTarget, EventParentPropertiesList);
         }
         var childTransmissionTarget = GetChildTransmissionTarget();
         if (childTransmissionTarget != null)
@@ -433,7 +433,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = ApplyPropertyToString(childTransmissionTarget, EventChildPropertiesList);
+                var propertyConfigurator = ConfigurePropertiesToString(childTransmissionTarget, EventChildPropertiesList);
                 if (_isCritical)
                 {
                     IDictionary<string, string> nullProps = null;
@@ -455,7 +455,7 @@ public class PuppetTransmission : MonoBehaviour
         PropertyConfigurator parentPropertyConfigurator = null;
         if (parentTransmissionTarget != null)
         {
-            parentPropertyConfigurator = ApplyPropertyToString(parentTransmissionTarget, EventParentPropertiesList);
+            parentPropertyConfigurator = ConfigurePropertiesToString(parentTransmissionTarget, EventParentPropertiesList);
         }
         var childTransmissionTarget = GetChildTransmissionTarget();
         if (childTransmissionTarget != null)
@@ -476,7 +476,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = ApplyPropertyToString(childTransmissionTarget, EventChildPropertiesList);
+                var propertyConfigurator = ConfigurePropertiesToString(childTransmissionTarget, EventChildPropertiesList);
                 if (_isCritical)
                 {
                     EventProperties nullProps = null;

--- a/Assets/Puppet/PuppetTransmission.cs
+++ b/Assets/Puppet/PuppetTransmission.cs
@@ -312,9 +312,9 @@ public class PuppetTransmission : MonoBehaviour
         OnChildUserIdChanged(null);
     }
 
-    private PropertyConfigurator ApplyParentPropertyToString(TransmissionTarget transmissionTarget)
+    private PropertyConfigurator ApplyPropertyToString(TransmissionTarget transmissionTarget, RectTransform eventProperties)
     {
-        var properties = PropertiesHelper.GetStringProperties(EventParentPropertiesList);
+        var properties = PropertiesHelper.GetStringProperties(eventProperties);
         var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
         foreach (var property in properties)
         {
@@ -325,10 +325,10 @@ public class PuppetTransmission : MonoBehaviour
         return propertyConfigurator;
     }
 
-    private PropertyConfigurator ApplyParentPropertyToType(TransmissionTarget transmissionTarget)
+    private PropertyConfigurator ApplyPropertyToType(TransmissionTarget transmissionTarget, RectTransform eventProperties)
     {
         var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
-        PropertiesHelper.AddPropertiesToPropertyConfigurator(EventParentPropertiesList, propertyConfigurator);
+        PropertiesHelper.AddPropertiesToPropertyConfigurator(eventProperties, propertyConfigurator);
         propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
         propertyConfigurator.RemoveEventProperty("extraEventProperty");
         return propertyConfigurator;
@@ -355,7 +355,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = ApplyParentPropertyToString(transmissionTarget);
+                var propertyConfigurator = ApplyPropertyToString(transmissionTarget, EventParentPropertiesList);
                 if (_isCritical)
                 {
                     IDictionary<string, string> nullProps = null;
@@ -391,7 +391,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = ApplyParentPropertyToType(transmissionTarget);
+                var propertyConfigurator = ApplyPropertyToType(transmissionTarget, EventParentPropertiesList);
                 if (_isCritical)
                 {
                     EventProperties nullProps = null;
@@ -412,7 +412,7 @@ public class PuppetTransmission : MonoBehaviour
         PropertyConfigurator parentPropertyConfigurator = null;
         if (parentTransmissionTarget != null)
         {
-            parentPropertyConfigurator = ApplyParentPropertyToString(parentTransmissionTarget);
+            parentPropertyConfigurator = ApplyPropertyToString(parentTransmissionTarget, EventParentPropertiesList);
         }
         var childTransmissionTarget = GetChildTransmissionTarget();
         if (childTransmissionTarget != null)
@@ -433,13 +433,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = childTransmissionTarget.GetPropertyConfigurator();
-                foreach (var property in properties)
-                {
-                    propertyConfigurator.SetEventProperty(property.Key, property.Value);
-                }
-                propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
-                propertyConfigurator.RemoveEventProperty("extraEventProperty");
+                var propertyConfigurator = ApplyPropertyToString(childTransmissionTarget, EventChildPropertiesList);
                 if (_isCritical)
                 {
                     System.Diagnostics.Debug.WriteLine("TrackEventStringPropertiesChildTransmission _isCritical");
@@ -462,7 +456,7 @@ public class PuppetTransmission : MonoBehaviour
         PropertyConfigurator parentPropertyConfigurator = null;
         if (parentTransmissionTarget != null)
         {
-            parentPropertyConfigurator = ApplyParentPropertyToString(parentTransmissionTarget);
+            parentPropertyConfigurator = ApplyPropertyToString(parentTransmissionTarget, EventParentPropertiesList);
         }
         var childTransmissionTarget = GetChildTransmissionTarget();
         if (childTransmissionTarget != null)
@@ -483,10 +477,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = childTransmissionTarget.GetPropertyConfigurator();
-                PropertiesHelper.AddPropertiesToPropertyConfigurator(EventChildPropertiesList, propertyConfigurator);
-                propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
-                propertyConfigurator.RemoveEventProperty("extraEventProperty");
+                var propertyConfigurator = ApplyPropertyToString(childTransmissionTarget, EventChildPropertiesList);
                 if (_isCritical)
                 {
                     EventProperties nullProps = null;

--- a/Assets/Puppet/PuppetTransmission.cs
+++ b/Assets/Puppet/PuppetTransmission.cs
@@ -312,6 +312,28 @@ public class PuppetTransmission : MonoBehaviour
         OnChildUserIdChanged(null);
     }
 
+    private PropertyConfigurator ApplyParentPropertyToString(TransmissionTarget transmissionTarget)
+    {
+        var properties = PropertiesHelper.GetStringProperties(EventParentPropertiesList);
+        var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
+        foreach (var property in properties)
+        {
+            propertyConfigurator.SetEventProperty(property.Key, property.Value);
+        }
+        propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
+        propertyConfigurator.RemoveEventProperty("extraEventProperty");
+        return propertyConfigurator;
+    }
+
+    private PropertyConfigurator ApplyParentPropertyToType(TransmissionTarget transmissionTarget)
+    {
+        var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
+        PropertiesHelper.AddPropertiesToPropertyConfigurator(EventParentPropertiesList, propertyConfigurator);
+        propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
+        propertyConfigurator.RemoveEventProperty("extraEventProperty");
+        return propertyConfigurator;
+    }
+
     public void TrackEventParentStringPropertiesTransmission()
     {
         var transmissionTarget = GetParentTransmissionTarget();
@@ -333,13 +355,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
-                foreach (var property in properties)
-                {
-                    propertyConfigurator.SetEventProperty(property.Key, property.Value);
-                }
-                propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
-                propertyConfigurator.RemoveEventProperty("extraEventProperty");
+                var propertyConfigurator = ApplyParentPropertyToString(transmissionTarget);
                 if (_isCritical)
                 {
                     IDictionary<string, string> nullProps = null;
@@ -375,10 +391,7 @@ public class PuppetTransmission : MonoBehaviour
             }
             else
             {
-                var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
-                PropertiesHelper.AddPropertiesToPropertyConfigurator(EventParentPropertiesList, propertyConfigurator);
-                propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
-                propertyConfigurator.RemoveEventProperty("extraEventProperty");
+                var propertyConfigurator = ApplyParentPropertyToType(transmissionTarget);
                 if (_isCritical)
                 {
                     EventProperties nullProps = null;
@@ -395,26 +408,32 @@ public class PuppetTransmission : MonoBehaviour
 
     public void TrackEventStringPropertiesChildTransmission()
     {
-        var transmissionTarget = GetChildTransmissionTarget();
-        if (transmissionTarget != null)
+        var parentTransmissionTarget = GetParentTransmissionTarget();
+        PropertyConfigurator parentPropertyConfigurator = null;
+        if (parentTransmissionTarget != null)
         {
-            OverrideChildProperties(transmissionTarget);
+            parentPropertyConfigurator = ApplyParentPropertyToString(parentTransmissionTarget);
+        }
+        var childTransmissionTarget = GetChildTransmissionTarget();
+        if (childTransmissionTarget != null)
+        {
+            OverrideChildProperties(childTransmissionTarget);
             var properties = PropertiesHelper.GetStringProperties(EventChildPropertiesList);
             if (properties == null)
             {
                 if (_isCritical)
                 {
                     IDictionary<string, string> nullProps = null;
-                    transmissionTarget.TrackEvent(EventName.text, nullProps, Flags.PersistenceCritical);
+                    childTransmissionTarget.TrackEvent(EventName.text, nullProps, Flags.PersistenceCritical);
                 }
                 else
                 {
-                    transmissionTarget.TrackEvent(EventName.text);
+                    childTransmissionTarget.TrackEvent(EventName.text);
                 }
             }
             else
             {
-                var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
+                var propertyConfigurator = childTransmissionTarget.GetPropertyConfigurator();
                 foreach (var property in properties)
                 {
                     propertyConfigurator.SetEventProperty(property.Key, property.Value);
@@ -423,54 +442,63 @@ public class PuppetTransmission : MonoBehaviour
                 propertyConfigurator.RemoveEventProperty("extraEventProperty");
                 if (_isCritical)
                 {
+                    System.Diagnostics.Debug.WriteLine("TrackEventStringPropertiesChildTransmission _isCritical");
                     IDictionary<string, string> nullProps = null;
-                    transmissionTarget.TrackEvent(EventName.text, nullProps, Flags.PersistenceCritical);
+                    childTransmissionTarget.TrackEvent(EventName.text, nullProps, Flags.PersistenceCritical);
                 }
                 else
                 {
-                    transmissionTarget.TrackEvent(EventName.text);
+                    childTransmissionTarget.TrackEvent(EventName.text);
                 }
                 PropertiesHelper.RemovePropertiesFromConfigurator(EventParentPropertiesList, propertyConfigurator);
             }
         }
+        PropertiesHelper.RemovePropertiesFromConfigurator(EventParentPropertiesList, parentPropertyConfigurator);
     }
 
     public void TrackEventTypedPropertiesChildTransmission()
     {
-        var transmissionTarget = GetChildTransmissionTarget();
-        if (transmissionTarget != null)
+        var parentTransmissionTarget = GetParentTransmissionTarget();
+        PropertyConfigurator parentPropertyConfigurator = null;
+        if (parentTransmissionTarget != null)
         {
-            OverrideChildProperties(transmissionTarget);
+            parentPropertyConfigurator = ApplyParentPropertyToString(parentTransmissionTarget);
+        }
+        var childTransmissionTarget = GetChildTransmissionTarget();
+        if (childTransmissionTarget != null)
+        {
+            OverrideChildProperties(childTransmissionTarget);
             var properties = PropertiesHelper.GetTypedProperties(EventChildPropertiesList);
             if (properties == null)
             {
                 if (_isCritical)
                 {
                     EventProperties nullProps = null;
-                    transmissionTarget.TrackEvent(EventName.text, nullProps, Flags.PersistenceCritical);
+                    childTransmissionTarget.TrackEvent(EventName.text, nullProps, Flags.PersistenceCritical);
                 }
                 else
                 {
-                    transmissionTarget.TrackEvent(EventName.text);
+                    childTransmissionTarget.TrackEvent(EventName.text);
                 }
             }
             else
             {
-                var propertyConfigurator = transmissionTarget.GetPropertyConfigurator();
+                var propertyConfigurator = childTransmissionTarget.GetPropertyConfigurator();
                 PropertiesHelper.AddPropertiesToPropertyConfigurator(EventChildPropertiesList, propertyConfigurator);
                 propertyConfigurator.SetEventProperty("extraEventProperty", "should be removed!");
                 propertyConfigurator.RemoveEventProperty("extraEventProperty");
                 if (_isCritical)
                 {
                     EventProperties nullProps = null;
-                    transmissionTarget.TrackEvent(EventName.text, nullProps, Flags.PersistenceCritical);
+                    childTransmissionTarget.TrackEvent(EventName.text, nullProps, Flags.PersistenceCritical);
                 }
                 else
                 {
-                    transmissionTarget.TrackEvent(EventName.text);
+                    childTransmissionTarget.TrackEvent(EventName.text);
                 }
                 PropertiesHelper.RemovePropertiesFromConfigurator(EventParentPropertiesList, propertyConfigurator);
             }
         }
+        PropertiesHelper.RemovePropertiesFromConfigurator(EventParentPropertiesList, parentPropertyConfigurator);
     }
 }

--- a/Assets/Puppet/PuppetTransmission.cs
+++ b/Assets/Puppet/PuppetTransmission.cs
@@ -436,7 +436,6 @@ public class PuppetTransmission : MonoBehaviour
                 var propertyConfigurator = ApplyPropertyToString(childTransmissionTarget, EventChildPropertiesList);
                 if (_isCritical)
                 {
-                    System.Diagnostics.Debug.WriteLine("TrackEventStringPropertiesChildTransmission _isCritical");
                     IDictionary<string, string> nullProps = null;
                     childTransmissionTarget.TrackEvent(EventName.text, nullProps, Flags.PersistenceCritical);
                 }

--- a/Assets/Puppet/Utility/PropertiesHelper.cs
+++ b/Assets/Puppet/Utility/PropertiesHelper.cs
@@ -52,6 +52,10 @@ public class PropertiesHelper
 
     public static void RemovePropertiesFromConfigurator(RectTransform propertiesContainer, PropertyConfigurator configurator)
     {
+        if (configurator == null)
+        {
+            return;
+        }
         var properties = propertiesContainer.GetComponentsInChildren<PuppetEventProperty>();
         if (properties == null || properties.Length == 0)
         {

--- a/Assets/Puppet/Utility/PropertiesHelper.cs
+++ b/Assets/Puppet/Utility/PropertiesHelper.cs
@@ -54,6 +54,7 @@ public class PropertiesHelper
     {
         if (configurator == null)
         {
+            Debug.Log("Property configurator is null. Can not remove properties from it.");
             return;
         }
         var properties = propertiesContainer.GetComponentsInChildren<PuppetEventProperty>();

--- a/Assets/Puppet/Utility/PropertiesHelper.cs
+++ b/Assets/Puppet/Utility/PropertiesHelper.cs
@@ -54,7 +54,7 @@ public class PropertiesHelper
     {
         if (configurator == null)
         {
-            Debug.Log("Property configurator is null. Can not remove properties from it.");
+            Debug.Log("Property configurator is null. Can't remove properties from it.");
             return;
         }
         var properties = propertiesContainer.GetComponentsInChildren<PuppetEventProperty>();


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [ ] ~Are tests passing locally?~
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Repro Steps

1. Open Unity Demo app
2. Select any Startup mode and restart demo app
3. Click Transmission target enter Event Name
4. Click Add Property button to add property "A" for Parent target
5. Then click Add Property button to add property "B" for Child target
6. Observe the result on Aria portal if the property "A" can be inherited to Child target

## Related PRs or issues

[AB#69752](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/69752)