### PR TITLE
Notifications replay after App Center initialized

### DIFF
--- a/Assets/AppCenter/AppCenterBehavior.cs
+++ b/Assets/AppCenter/AppCenterBehavior.cs
@@ -108,11 +108,6 @@ public class AppCenterBehavior : MonoBehaviour
                 if (startCrashes != null)
                     startCrashes.Invoke(null, null);
 #endif
-#if UNITY_IOS
-                var startPush = service.GetMethod("StartPush");
-                if (startPush != null)
-                    startPush.Invoke(null, null);
-#endif
             }
         }
 #endif

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Push/Android/PushInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Push/Android/PushInternal.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AppCenter.Unity.Push.Internal
         private static void Initialize()
         {
             _unityListener.CallStatic("setListener", new PushDelegate());
-            Push.ReplayPushNotificationsIfWaiting();         
         }
 
         public static void StartPush()
@@ -35,6 +34,7 @@ namespace Microsoft.AppCenter.Unity.Push.Internal
             AndroidJavaClass unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
             AndroidJavaObject activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
             instance.Call("onActivityResumed", activity);
+            Push.ReplayPushNotificationsIfWaiting();
         }
 
         public static AppCenterTask SetEnabledAsync(bool isEnabled)

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Push/UWP/PushInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Push/UWP/PushInternal.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AppCenter.Unity.Push.Internal
         public static void PrepareEventHandlers()
         {
             AppCenterBehavior.InitializingServices += Initialize;
+            AppCenterBehavior.InitializedAppCenterAndServices += PostInitialize;
         }
 
         public static void StartPush()
@@ -57,6 +58,10 @@ namespace Microsoft.AppCenter.Unity.Push.Internal
                 };
                 HandlePushNotification(eventArgs);
             };
+        }
+
+        private static void PostInitialize()
+        {
             Push.ReplayPushNotificationsIfWaiting();
         }
 

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Push/iOS/PushInternal.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Push/iOS/PushInternal.cs
@@ -30,12 +30,17 @@ namespace Microsoft.AppCenter.Unity.Push.Internal
         public static void PrepareEventHandlers()
         {
             AppCenterBehavior.InitializingServices += Initialize;
+            AppCenterBehavior.InitializedAppCenterAndServices += PostInitialize;
         }
 
         private static void Initialize()
         {
             _receivedPushDel = ReceivedPushNotificationFunc;
             appcenter_unity_push_set_received_push_impl(_receivedPushDel);
+        }
+
+        private static void PostInitialize()
+        {
             Push.ReplayPushNotificationsIfWaiting();
         }
 

--- a/Assets/AppCenter/Plugins/iOS/Core/AppCenterStarter.original
+++ b/Assets/AppCenter/Plugins/iOS/Core/AppCenterStarter.original
@@ -126,6 +126,7 @@ static const int kMSStartupType = 0 /*STARTUP_TYPE*/;
     [MSAppCenter setLogUrl:kMSCustomLogUrl];
 #endif
   }
+  [classes addObject:MSPush.class];
   NSString *customAppSecret = [[NSUserDefaults standardUserDefaults] objectForKey:kMSAppSecretKey];
   NSString *customAppSecretValue = customAppSecret == nil ? kMSAppSecret : customAppSecret;
   switch (startTargetValue) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * **[Bug fix]** Fix missed push notification window if notification was received after the application closed.
 
+___
+
 ## Release 2.6.0
 
 Updated native SDK versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### iOS/UWP
 
-* **[Bug fix]** Fix missed push notification window if notification was received after the application closed.
+* **[Bug fix]** Fix triggering the notification event when restarting the application from a notification.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,11 @@
 
 ### App Center Push
 
+* **[Bug fix]** Fix triggering the notification event when restarting the application from a notification.
+
 #### iOS
 
 * **[Fix]** Fix an issue where Push could not be started because `StartPush` method was stripped for a high managed stripping level.
-
-#### iOS/UWP
-
-* **[Bug fix]** Fix triggering the notification event when restarting the application from a notification.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for Unity Change Log
 
+## Version 2.6.1 (Under development)
+
+### App Center Push 
+
+#### iOS/UWP
+
+* **[Bug fix]** Fix missed push notification window if notification was received after the application closed.
+
 ## Release 2.6.0
 
 Updated native SDK versions:


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The `ReplayPushNotificationsIfWaiting` called after the `App Center` fully initialized.

## Misc

[AB#65076](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/65076)
