### PR TITLE
Android 6. IllegalArgumentException in JavaHelper.JavaDateFormatter fixed

### DIFF
--- a/Assets/AppCenter/Plugins/Android/Utility/JavaDateHelper.cs
+++ b/Assets/AppCenter/Plugins/Android/Utility/JavaDateHelper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AppCenter.Unity.Internal.Utility
             {
                 if (_javaDateFormatter == null)
                 {
-                    _javaDateFormatter = new AndroidJavaObject("java.text.SimpleDateFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+                    _javaDateFormatter = new AndroidJavaObject("java.text.SimpleDateFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
                 }
                 return _javaDateFormatter;
             }
@@ -28,6 +28,8 @@ namespace Microsoft.AppCenter.Unity.Internal.Utility
         public static AndroidJavaObject DateTimeConvert(DateTime date)
         {
             var dateString = date.ToString(DotNetDateFormat);
+            int separatorIndex = dateString.LastIndexOf(CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator);
+            dateString = dateString.Remove(separatorIndex, 1);
             return JavaDateFormatter.Call<AndroidJavaObject>("parse", dateString);
         }
 

--- a/Assets/AppCenter/Plugins/Android/Utility/JavaDateHelper.cs
+++ b/Assets/AppCenter/Plugins/Android/Utility/JavaDateHelper.cs
@@ -27,6 +27,9 @@ namespace Microsoft.AppCenter.Unity.Internal.Utility
 
         public static AndroidJavaObject DateTimeConvert(DateTime date)
         {
+            // 'DotNetDateFormat' contains timezone info with time separator. 
+            // 'javaDateFormatter' uses date format with timezone info without time separator.
+            // Time separator should be removed from date string before 'parse' call.
             var dateString = date.ToString(DotNetDateFormat);
             int separatorIndex = dateString.LastIndexOf(CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator);
             dateString = dateString.Remove(separatorIndex, 1);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Android
 
 * **[Fix]** Fix a Unity warning that appears when building for Android.
+* **[Fix]** Fix a `java.lang.IllegalArgumentException: Unknown pattern character 'X'` in `JavaHelper.JavaDateFormatter` on Android 6.
 
 ### App Center Auth
 


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

JavaHelper.JavaDateFormatter throws exception "java.lang.IllegalArgumentException: Unknown pattern character 'X'" on Android 6. The date format was updated.

## Related PRs or issues

[AB#74055](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/74055)