### PR TITLE
The function appcenter_unity_ns_string_to_cstr copies an NSString to char* incorrectly

### DIFF
--- a/Assets/AppCenter/Plugins/iOS/Core/Utility/NSStringHelper.mm
+++ b/Assets/AppCenter/Plugins/iOS/Core/Utility/NSStringHelper.mm
@@ -15,8 +15,8 @@ const char* appcenter_unity_ns_string_to_cstr(NSString* nsstring)
   // converted to a System.String in C#, the char array is freed - which causes
   // a double-deallocation if ARC also tries to free it. To prevent this, we
   // must return a manually allocated copy of the string returned by "UTF8String"
-  size_t cstringLength = [nsstring length] + 1; // +1 for '\0'
   const char *cstring = [nsstring UTF8String];
+  size_t cstringLength = strlen(cstring) + 1; // +1 for '\0'
   char *cstring_copy = (char*)malloc(cstringLength);
   strncpy(cstring_copy, cstring, cstringLength);
   return cstring_copy;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ### App Center
 
-* **[Fix]** Fix converting string properties to chars after converting to UTF-8.
-
 #### Android
 
 * **[Fix]** Fix a Unity warning that appears when building for Android.
 * **[Fix]** Fix a `java.lang.IllegalArgumentException: Unknown pattern character 'X'` in `JavaHelper.JavaDateFormatter` on Android 6.
+
+#### iOS
+
+* **[Fix]** Fix converting string with the Unicode symbols (for example in push notification).
 
 ### App Center Auth
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center
 
-* **[Fix]** Fix converting string properties to chars.
+* **[Fix]** Fix converting string properties to chars after converting to UTF-8.
 
 #### Android
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### App Center
 
+* **[Fix]** Fix converting string properties to chars.
+
 #### Android
 
 * **[Fix]** Fix a Unity warning that appears when building for Android.


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] ~Are tests passing locally?~
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Related PRs or issues

[AB#76723](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/76723)
