### PR TITLE
Add logging timeout to print last error

### DIFF
--- a/utility.cake
+++ b/utility.cake
@@ -66,7 +66,7 @@ static int ExecuteUnityCommand(string extraArgs, string projectPath = ".")
         {
             unityProcess.WaitForExit();
             result = unityProcess.GetExitCode();
-            if (logProcess.WaitForExit(0) && (logProcess.GetExitCode() != 0))
+            if (logProcess.WaitForExit(1000) && (logProcess.GetExitCode() != 0))
             {
                 Statics.Context.Warning("There was an error logging, but command still executed.");
             }


### PR DESCRIPTION
The log process didn't write the last error. It was killed too fast. In addition we delete log file, so the error message was completely missed even local (and for sure on CI)

[AB#77174](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/77174)