### PR TITLE
UpdateTrack enum removed from AppCenterSettings

### DIFF
--- a/Assets/AppCenter/AppCenterSettings.cs
+++ b/Assets/AppCenter/AppCenterSettings.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AppCenter.Unity;
-using Microsoft.AppCenter.Unity.Distribute;
 using UnityEngine;
 
 [Serializable]
@@ -48,7 +47,9 @@ public class AppCenterSettings : ScriptableObject
 
     public LogLevel InitialLogLevel = LogLevel.Info;
 
-    public UpdateTrack UpdateTrack = UpdateTrack.Public;
+    [CustomDropDownProperty("Public", 1)]
+    [CustomDropDownProperty("Private", 2)]
+    public int UpdateTrack;
 
     public CustomUrlProperty CustomLogUrl = new CustomUrlProperty("Log");
 

--- a/Assets/AppCenter/Editor/AppCenterPreBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPreBuild.cs
@@ -144,7 +144,7 @@ public class AppCenterPreBuild : IPreprocessBuildWithReport
             {
                 settingsMaker.SetDistributeDisableAutomaticCheckForUpdate();
             }
-            settingsMaker.SetUpdateTrack((int)settings.UpdateTrack);
+            settingsMaker.SetUpdateTrack(settings.UpdateTrack);
             settingsMaker.StartDistributeClass();
         }
         if (advancedSettings != null)

--- a/Assets/AppCenter/Editor/CustomDropDownPropertyDrawer.cs
+++ b/Assets/AppCenter/Editor/CustomDropDownPropertyDrawer.cs
@@ -9,31 +9,31 @@ using UnityEngine;
 [CustomPropertyDrawer(typeof(CustomDropDownPropertyAttribute))]
 public class CustomDropDownPropertyDrawer : PropertyDrawer
 {
-    bool initialized = false;
-    object[] attributes = null;
-    Dictionary<string, int> optionsDictionary = new Dictionary<string, int>();
-    string[] options = null;
-    int selectedIndex = 0;
+    bool _initialized = false;
+    object[] _attributes = null;
+    Dictionary<string, int> _optionsDictionary = new Dictionary<string, int>();
+    string[] _options = null;
+    int _selectedIndex = 0;
 
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
     {
-        if (!initialized)
+        if (!_initialized)
         {
-            attributes = fieldInfo.GetCustomAttributes(typeof(CustomDropDownPropertyAttribute), false);
-            foreach (var itemAttribute in attributes)
+            _attributes = fieldInfo.GetCustomAttributes(typeof(CustomDropDownPropertyAttribute), false);
+            foreach (var itemAttribute in _attributes)
             {
                 var customPropertyAttribute = itemAttribute as CustomDropDownPropertyAttribute;
-                optionsDictionary.Add(customPropertyAttribute.SelectedKey, customPropertyAttribute.SelectedValue);
+                _optionsDictionary.Add(customPropertyAttribute.SelectedKey, customPropertyAttribute.SelectedValue);
                 if (customPropertyAttribute.SelectedValue == AppCenterSettingsContext.SettingsInstance.UpdateTrack)
                 {
-                    selectedIndex = ArrayUtility.IndexOf(attributes, itemAttribute);
+                    _selectedIndex = ArrayUtility.IndexOf(_attributes, itemAttribute);
                 }
             }
-            options = optionsDictionary.Keys.ToArray();
-            initialized = true;
+            _options = _optionsDictionary.Keys.ToArray();
+            _initialized = true;
         }
 
-        selectedIndex = EditorGUI.Popup(position, property.displayName, selectedIndex, options);
-        property.intValue = optionsDictionary[options[selectedIndex]];
+        _selectedIndex = EditorGUI.Popup(position, property.displayName, _selectedIndex, _options);
+        property.intValue = _optionsDictionary[_options[_selectedIndex]];
     }
 }

--- a/Assets/AppCenter/Editor/CustomDropDownPropertyDrawer.cs
+++ b/Assets/AppCenter/Editor/CustomDropDownPropertyDrawer.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(CustomDropDownPropertyAttribute))]
+public class CustomDropDownPropertyDrawer : PropertyDrawer
+{
+    bool initialized = false;
+    object[] attributes = null;
+    Dictionary<string, int> optionsDictionary = new Dictionary<string, int>();
+    string[] options = null;
+    int selectedIndex = 0;
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        if (!initialized)
+        {
+            attributes = fieldInfo.GetCustomAttributes(typeof(CustomDropDownPropertyAttribute), false);
+            foreach (var itemAttribute in attributes)
+            {
+                var customPropertyAttribute = itemAttribute as CustomDropDownPropertyAttribute;
+                optionsDictionary.Add(customPropertyAttribute.SelectedKey, customPropertyAttribute.SelectedValue);
+                if (customPropertyAttribute.SelectedValue == AppCenterSettingsContext.SettingsInstance.UpdateTrack)
+                {
+                    selectedIndex = ArrayUtility.IndexOf(attributes, itemAttribute);
+                }
+            }
+            options = optionsDictionary.Keys.ToArray();
+            initialized = true;
+        }
+
+        selectedIndex = EditorGUI.Popup(position, property.displayName, selectedIndex, options);
+        property.intValue = optionsDictionary[options[selectedIndex]];
+    }
+}

--- a/Assets/AppCenter/Editor/CustomDropDownPropertyDrawer.cs.meta
+++ b/Assets/AppCenter/Editor/CustomDropDownPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0e8996e972247549b62c85a8d7aa869
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AppCenter/Properties/CustomDropDownPropertyAttribute.cs
+++ b/Assets/AppCenter/Properties/CustomDropDownPropertyAttribute.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using UnityEngine;
+
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
+public class CustomDropDownPropertyAttribute : PropertyAttribute
+{
+    public CustomDropDownPropertyAttribute(string _key, int _value)
+    {
+        SelectedKey = _key;
+        SelectedValue = _value;
+    }
+
+    public CustomDropDownPropertyAttribute()
+    { }
+
+    public string SelectedKey;
+    public int SelectedValue;
+}

--- a/Assets/AppCenter/Properties/CustomDropDownPropertyAttribute.cs
+++ b/Assets/AppCenter/Properties/CustomDropDownPropertyAttribute.cs
@@ -7,15 +7,16 @@ using UnityEngine;
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
 public class CustomDropDownPropertyAttribute : PropertyAttribute
 {
-    public CustomDropDownPropertyAttribute(string _key, int _value)
+    public CustomDropDownPropertyAttribute(string key, int value)
     {
-        SelectedKey = _key;
-        SelectedValue = _value;
+        SelectedKey = key;
+        SelectedValue = value;
     }
 
     public CustomDropDownPropertyAttribute()
-    { }
+    {
+    }
 
-    public string SelectedKey;
-    public int SelectedValue;
+    public string SelectedKey { get; private set; }
+    public int SelectedValue { get; private set; }
 }

--- a/Assets/AppCenter/Properties/CustomDropDownPropertyAttribute.cs.meta
+++ b/Assets/AppCenter/Properties/CustomDropDownPropertyAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7647137f3538f414bbcdbd68470d7029
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### App Center
 
+* **[Fix]** Fix SDK doesn't work without `Distribute` package.
+
 #### iOS
 
 * **[Fix]** Add missing system dependencies that aren't implicitly included when `APPCENTER_DONT_USE_NATIVE_STARTER` flag is used.


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

'UpdateTrack' enum was removed from the 'AppCenterSettings' class. A new attribute added to draw dropdown in the editor GUI.

## Related PRs or issues

[AB#78905](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/78905)
