### PR TITLE
When disabled "Report Unhandled Exceptions" the reports still sending

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
@@ -48,9 +48,14 @@ namespace Microsoft.AppCenter.Unity.Crashes
         public static void TrackError(Exception exception, IDictionary<string, string> properties = null, params ErrorAttachmentLog[] attachments)
         {
             if (exception != null)
+            if (exception != null && _reportUnhandledExceptions)
             {
                 var exceptionWrapper = CreateWrapperException(exception);
                 CrashesInternal.TrackException(exceptionWrapper.GetRawObject(), properties, attachments);
+            }
+            else
+            {
+                Debug.LogWarning("Cannot sending track exception without enabling unhandled exception reporting.");
             }
         }
 

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AppCenter.Unity.Crashes
             }
             else
             {
-                Debug.LogWarning("Cannot sending track exception without enabling unhandled exception reporting.");
+                Debug.LogWarning($"'Crashes.TrackException' wasn't sent. Make sure that unhandled exception reporting is enabled and 'exception' value isn't null.");
             }
         }
 

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
@@ -47,7 +47,6 @@ namespace Microsoft.AppCenter.Unity.Crashes
 
         public static void TrackError(Exception exception, IDictionary<string, string> properties = null, params ErrorAttachmentLog[] attachments)
         {
-            if (exception != null)
             if (exception != null && _reportUnhandledExceptions)
             {
                 var exceptionWrapper = CreateWrapperException(exception);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### App Center
 
 * **[Fix]** Fix SDK doesn't work without `Distribute` package.
+
+### App Center Crashes
+
 * **[Fix]** Fix sending `Crashes.TrackException` after disabling `Crashes.ReportUnhandledExceptions`.
 
 #### iOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center
 
 * **[Fix]** Fix SDK doesn't work without `Distribute` package.
+* **[Fix]** Fix sending `Crashes.TrackException` after disabling `Crashes.ReportUnhandledExceptions`.
 
 #### iOS
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.34.1" />
+    <package id="Cake" version="0.37.0" />
 </packages>


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

**Repro Steps**

1. Installed Unity iOS/Android demo app, and launch app.
2. Go to Crashes module page.
3. Uncheck "Report Unhandled Exceptions".
4. Then click "Test Handled Error".
5. Go to Diagnostics--> Issues page on portal, observe the error report shows on portal. .

**Expected Behaviour**
When disabled "Report Unhandled Exceptions" and click "Test Handled Error", the portal can't receive error report.

**Actual Behaviour**
When disabled "Report Unhandled Exceptions" and click "Test Handled Error", the portal can receive error report.

## Related PRs or issues

[AB#78493](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/78493)
