### PR TITLE
IOS new thread exception crash report fix

### DIFF
--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
@@ -78,11 +78,20 @@ namespace Microsoft.AppCenter.Unity.Crashes
             if (exception != null)
             {
                 Debug.Log("Unhandled exception: " + exception.ToString());
+#if UNITY_IOS && !UNITY_EDITOR
+                var exceptionWrapper = CreateWrapperException(exception);
+                var errorId = CrashesInternal.TrackException(exceptionWrapper.GetRawObject(), null, null);
+                if (_enableErrorAttachmentsCallbacks)
+                {
+                    SendErrorAttachments(errorId);
+                }
+#else
                 lock (_unhandledExceptions)
                 {
                     _unhandledExceptions.Enqueue(exception);
                 }
                 UnityCoroutineHelper.StartCoroutine(SendUnhandledExceptionReports);
+#endif
             }
         }
 #endif

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
@@ -79,12 +79,7 @@ namespace Microsoft.AppCenter.Unity.Crashes
             {
                 Debug.Log("Unhandled exception: " + exception.ToString());
 #if UNITY_IOS && !UNITY_EDITOR
-                var exceptionWrapper = CreateWrapperException(exception);
-                var errorId = CrashesInternal.TrackException(exceptionWrapper.GetRawObject(), null, null);
-                if (_enableErrorAttachmentsCallbacks)
-                {
-                    SendErrorAttachments(errorId);
-                }
+                TrackErrorWithAttachments(exception);
 #else
                 lock (_unhandledExceptions)
                 {
@@ -335,17 +330,24 @@ namespace Microsoft.AppCenter.Unity.Crashes
                 }
                 if (exception != null)
                 {
-                    var exceptionWrapper = CreateWrapperException(exception);
-                    var errorId = CrashesInternal.TrackException(exceptionWrapper.GetRawObject(), null, null);
-                    if (_enableErrorAttachmentsCallbacks)
-                    {
-                        SendErrorAttachments(errorId);
-                    }
+                    TrackErrorWithAttachments(exception);
                 }
                 yield return null; // report remaining exceptions on next frames
             }
         }
 #endif
+
+        private static void TrackErrorWithAttachments(Exception exception)
+		{
+            var exceptionWrapper = CreateWrapperException(exception);
+            var errorId = CrashesInternal.TrackException(exceptionWrapper.GetRawObject(), null, null);
+
+            // when the main thread was not crashed attachments should be sent
+            if (_enableErrorAttachmentsCallbacks)
+            {
+                SendErrorAttachments(errorId);
+            }
+        }
 
         private static WrapperException CreateWrapperException(Exception exception)
         {

--- a/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
+++ b/Assets/AppCenter/Plugins/AppCenterSDK/Crashes/Shared/Crashes.cs
@@ -338,11 +338,11 @@ namespace Microsoft.AppCenter.Unity.Crashes
 #endif
 
         private static void TrackErrorWithAttachments(Exception exception)
-		{
+        {
             var exceptionWrapper = CreateWrapperException(exception);
             var errorId = CrashesInternal.TrackException(exceptionWrapper.GetRawObject(), null, null);
 
-            // when the main thread was not crashed attachments should be sent
+            // If the main thread is not crashed, attachments should be sent.
             if (_enableErrorAttachmentsCallbacks)
             {
                 SendErrorAttachments(errorId);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### iOS
 
-* **[Fix]** Fix new thread exception crash report don't send.
+* **[Fix]** Fix reporting crashes caused by a thread exception.
 
 ## Release 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for Unity Change Log
 
+## Release 3.2.1 (in development)
+
+### App Center
+
+#### iOS
+
+* **[Fix]** Fix new thread exception crash report don't send.
+
 ## Release 3.2.0
 
 ### App Center


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Ne thread excpetion crash repot don't send because of unity coroutine don't work for this case. Now iOS crash report send without coroutine. 

## Related PRs or issues

[AB#78491](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/78491)
