### PR TITLE
App Center post-build does not override custom URL Scheme

### DIFF
--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -422,15 +422,19 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
         {
             // Add App Center URL scemes.
             var schemes = new List<string>() { "None" };
-            Type playerSettingsClass = typeof(PlayerSettings.iOS);
 
+            // Create a reflection call for getting custom schemes from iOS settings.
+            Type playerSettingsClass = typeof(PlayerSettings.iOS);
             MethodInfo iOSURLSchemesMethod = playerSettingsClass.GetMethod("GetURLSchemes", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Static);
+
+            // Verify that method is exist and call it for getting custom schemes.
             if (iOSURLSchemesMethod != null)
             {
                 var schemesFromSettings = (string[])iOSURLSchemesMethod.Invoke(null, null);
                 schemes.AddRange(schemesFromSettings.ToList<string>());
             }
 
+            // Generate scheme information.
             var root = info.GetRoot();
             var urlTypes = root.GetType().GetMethod("CreateArray").Invoke(root, new object[] { "CFBundleURLTypes" });
             foreach (var scheme in schemes) 

--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -424,8 +424,8 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
             var schemes = new List<string>() { "appcenter-" + settings.iOSAppSecret  };
 
             // Create a reflection call for getting custom schemes from iOS settings.
-            Type playerSettingsClass = typeof(PlayerSettings.iOS);
-            MethodInfo iOSURLSchemesMethod = playerSettingsClass.GetMethod("GetURLSchemes", BindingFlags.Static | BindingFlags.NonPublic);
+            var playerSettingsClass = typeof(PlayerSettings.iOS);
+            var iOSURLSchemesMethod = playerSettingsClass.GetMethod("GetURLSchemes", BindingFlags.Static | BindingFlags.NonPublic);
 
             // Verify that method exists and call it for getting custom schemes.
             if (iOSURLSchemesMethod != null)

--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -421,11 +421,11 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
         if (settings.UseDistribute && AppCenter.Distribute != null)
         {
             // Add App Center URL scemes.
-            var schemes = new List<string>();
+            var schemes = new List<string>() { "appcenter-" + settings.iOSAppSecret  };
 
             // Create a reflection call for getting custom schemes from iOS settings.
             Type playerSettingsClass = typeof(PlayerSettings.iOS);
-            MethodInfo iOSURLSchemesMethod = playerSettingsClass.GetMethod("GetURLSchemes", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo iOSURLSchemesMethod = playerSettingsClass.GetMethod("GetURLSchemes", BindingFlags.Static | BindingFlags.NonPublic);
 
             // Verify that method is exist and call it for getting custom schemes.
             if (iOSURLSchemesMethod != null)
@@ -444,7 +444,7 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
                 setStringMethod.Invoke(urlType, new object[] { "CFBundleTypeRole", "None" });
                 setStringMethod.Invoke(urlType, new object[] { "CFBundleURLName", ApplicationIdHelper.GetApplicationId() });
                 var urlSchemes = urlType.GetType().GetMethod("CreateArray").Invoke(urlType, new[] { "CFBundleURLSchemes" });
-                urlSchemes.GetType().GetMethod("AddString").Invoke(urlSchemes, new[] { "appcenter-" + settings.iOSAppSecret });
+
                 // Add custom schemes defined in Unity players settings.
                 foreach (var scheme in schemes)
                 {

--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -12,6 +12,7 @@ using UnityEditor.Build.Reporting;
 using UnityEditor.Build;
 using UnityEditor;
 using UnityEngine;
+using System.Reflection;
 
 // Warning: Don't use #if #endif for conditional compilation here as Unity
 // doesn't always set the flags early enough.
@@ -419,17 +420,30 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
     {
         if (settings.UseDistribute && AppCenter.Distribute != null)
         {
-            // Add App Center URL sceme.
+            // Add App Center URL scemes.
+            var schemes = new List<string>() { "None" };
+            Type playerSettingsClass = typeof(PlayerSettings.iOS);
+
+            MethodInfo iOSURLSchemesMethod = playerSettingsClass.GetMethod("GetURLSchemes", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Static);
+            if (iOSURLSchemesMethod != null)
+            {
+                var schemesFromSettings = (string[])iOSURLSchemesMethod.Invoke(null, null);
+                schemes.AddRange(schemesFromSettings.ToList<string>());
+            }
+
             var root = info.GetRoot();
             var urlTypes = root.GetType().GetMethod("CreateArray").Invoke(root, new object[] { "CFBundleURLTypes" });
-            if (settings.UseDistribute && AppCenter.Distribute != null)
+            foreach (var scheme in schemes) 
             {
-                var urlType = urlTypes.GetType().GetMethod("AddDict").Invoke(urlTypes, null);
-                var setStringMethod = urlType.GetType().GetMethod("SetString");
-                setStringMethod.Invoke(urlType, new object[] { "CFBundleTypeRole", "None" });
-                setStringMethod.Invoke(urlType, new object[] { "CFBundleURLName", ApplicationIdHelper.GetApplicationId() });
-                var urlSchemes = urlType.GetType().GetMethod("CreateArray").Invoke(urlType, new[] { "CFBundleURLSchemes" });
-                urlSchemes.GetType().GetMethod("AddString").Invoke(urlSchemes, new[] { "appcenter-" + settings.iOSAppSecret });
+                if (settings.UseDistribute && AppCenter.Distribute != null)
+                {
+                    var urlType = urlTypes.GetType().GetMethod("AddDict").Invoke(urlTypes, null);
+                    var setStringMethod = urlType.GetType().GetMethod("SetString");
+                    setStringMethod.Invoke(urlType, new object[] { "CFBundleTypeRole", scheme });
+                    setStringMethod.Invoke(urlType, new object[] { "CFBundleURLName", ApplicationIdHelper.GetApplicationId() });
+                    var urlSchemes = urlType.GetType().GetMethod("CreateArray").Invoke(urlType, new[] { "CFBundleURLSchemes" });
+                    urlSchemes.GetType().GetMethod("AddString").Invoke(urlSchemes, new[] { "appcenter-" + settings.iOSAppSecret });
+                }
             }
         }
     }

--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -427,7 +427,7 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
             Type playerSettingsClass = typeof(PlayerSettings.iOS);
             MethodInfo iOSURLSchemesMethod = playerSettingsClass.GetMethod("GetURLSchemes", BindingFlags.Static | BindingFlags.NonPublic);
 
-            // Verify that method is exist and call it for getting custom schemes.
+            // Verify that method exists and call it for getting custom schemes.
             if (iOSURLSchemesMethod != null)
             {
                 var schemesFromSettings = (string[])iOSURLSchemesMethod.Invoke(null, null);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # App Center SDK for Unity Change Log
 
+## Release 3.3.1 (Under development)
+
+### App Center
+
+#### iOS
+
+* **[Fix]** Fix override custom `URLScheme` in the post-build script.
+
+___
+
 ## Release 3.3.0
 
 This version has a breaking change on iOS - it drops Xcode 10 support, Xcode 11 is a minimal supported version now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### iOS
 
-* **[Fix]** Fix override custom `URLScheme` in the post-build script.
+* **[Fix]** Fix overriding custom `URLScheme` in the post-build script.
 
 ___
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

1. Create a Unity project for iOS
2. Implement the AppCenter Unity plugin and turn on Distribute feature
3. Define new URL scheme (ex. "myscheme") in Unity project settings: Player Settings->iOS->Other settings->Configuration section->Supported URL Scheme
4. Build an iOS project

**Current behavior**
`Info.plist` contains only one entry in `CFBundleURLTypes` array for `appcenter-xxxxx`.

**Expected behavior** 
`Info.plist` contains two `appcenter-xxxxx` and `myscheme` entries in `CFBundleURLTypes` array.

## Related PRs or issues

[AB#82424](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/82424)
