### PR TITLE
Duplicate AppCenter shouldn't really be an Error

### DIFF
--- a/Assets/AppCenter/AppCenterBehavior.cs
+++ b/Assets/AppCenter/AppCenterBehavior.cs
@@ -24,7 +24,7 @@ public class AppCenterBehavior : MonoBehaviour
         // Make sure that App Center have only one instance.
         if (_instance != null)
         {
-            Debug.LogError("App Center Behavior should have only one instance!");
+            Debug.Log("App Center Behavior should have only one instance!");
             DestroyImmediate(gameObject);
             return;
         }


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

There's plenty of scenarios where this is going to happen, especially in apps where you go back and forth between scenes. Printing an Error rather than just an Informational warning when _nothing bad happens_ as a result seems like bad practice IMO.

## Related PRs or issues

N/A

## Misc

N/A
