### PR TITLE
removed apndroid:autoBackup and android:supportsRtl from AppCenterLoaderApp/appcenter-loader/src/main/AndroidManifest.xml.

### DIFF
--- a/AppCenterLoaderApp/appcenter-loader/src/main/AndroidManifest.xml
+++ b/AppCenterLoaderApp/appcenter-loader/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.microsoft.appcenter.loader">
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
+    <application android:label="@string/app_name">
         <provider
             android:authorities="${applicationId}.microsoft.appcenter.loader"
             android:exported="false"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### AppCenter
 
 * **[Feature]** Add a `AppCenter.IsNetworkRequestsAllowed` API to block any network requests without disabling the SDK.
+* **[Fix]** Fix removing `android:allowBackup` and `android:supportsRtl` from AndroidManifest.xml in appcenter-loader-release.aar, as these attributes will be unintentionally merged into the final AndroidManifest.xml in the app.
 
 ___
 


### PR DESCRIPTION
## Description

Two attributes `android:autoBackup` and `android:supportsRtl` are defined by AndroidManifest.xml in appcenter-loader-release.aar, and these will be unintentionally merged into the final app. This patch removes them.
