### PR TITLE
Fix crash in appcenter-loader when getContext() doesn't return the application context

### DIFF
--- a/AppCenterLoaderApp/appcenter-loader/src/main/java/com/microsoft/appcenter/loader/AppCenterLoader.java
+++ b/AppCenterLoaderApp/appcenter-loader/src/main/java/com/microsoft/appcenter/loader/AppCenterLoader.java
@@ -199,7 +199,7 @@ public class AppCenterLoader extends ContentProvider {
     private Context getApplicationContext() {
 
         //TODO: if Unity supports instant apps, need to modify this method to account for them
-        return getContext();
+        return getContext().getApplicationContext();
     }
 
     private boolean isTrueValue(String value) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * **[Breaking change]** Remove `AppCenter.SetCustomProperties` API.
 
+#### Android
+
+* **[Fix]** Fix crash when `getContext()` in `appcenter-loader` doesn't return the Application Context
+
 ### App Center Analytics
 
  * **[Feature]** Add `Analytics.EnableManualSessionTracker` and `Analytics.StartSession` APIs for tracking session manually.


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
- Tested on our project that uses both the AppCenter and Intune where the crash was occurring. I'll setup a blank project and test there as well. 

## Description
This PR ensures that `getApplicationContext()` in AppCenter-loader grabs the application context. Previously this could return a an activity context, causing a crash when used alongside Intune. 

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-unity/issues/505