### PR TITLE
Fix building Android Unity player from Linux OS

### DIFF
--- a/Assets/AppCenter/Editor/AndroidLibraryHelper.cs
+++ b/Assets/AppCenter/Editor/AndroidLibraryHelper.cs
@@ -27,7 +27,7 @@ public static class AndroidLibraryHelper
                 .ToString();
             processName = "cmd";
         }
-        else if (Application.platform == RuntimePlatform.OSXEditor)
+        else if (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.LinuxEditor)
         {
             args = stringBuilder
                 .Append("-c \"cd ")

--- a/Assets/AppCenter/Editor/AndroidLibraryHelper.cs
+++ b/Assets/AppCenter/Editor/AndroidLibraryHelper.cs
@@ -65,7 +65,7 @@ public static class AndroidLibraryHelper
                 .ToString();
             processName = "cmd";
         }
-        else if (Application.platform == RuntimePlatform.OSXEditor)
+        else if (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.LinuxEditor)
         {
             args = stringBuilder
                    .Append("-c \"unzip ")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 4.4.1 (Under active development)
 
+#### Android
+
+* **[Fix]** Fix building the Unity Player Android client from a Linux OS.
+
 ___
 
 ## Version 4.4.0


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

When building the Unity Player for the Android platform on a linux based system, it does not perform the unzip operation while building and this results in a crash at runtime due to missing files.

## Misc

There is also a `ZipFile` function in the same file that I have not tracked down what it is used for. It was not needed to fix the problem although likely a subsequent follow up issue should be created to investigate.
