### PR TITLE
Fix build APPX packages on version 2021.X.X and higher 

### DIFF
--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -117,21 +117,6 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
 
         var insertingPosition = GetFirstLineInMethodBody(codeLines, logMethodLineIndex);
 
-        /*
-        var counter = 5;
-        foreach (string s in codeLines)
-        {
-            codeLines.Insert(lastIncludeLineIndex + counter, $"\/* {s} *\/");
-            counter += 1;
-        }
-        */
-
-        var len = codeLines.Count;
-        
-        for (int i = 0; i < len; i++) {
-            codeLines.Insert(lastIncludeLineIndex, codeLines[i]);
-        }
-
 #if UNITY_2021_1_OR_NEWER
         codeLines.Insert(insertingPosition, "OutputDebugStringW((*message)->chars);");
 #else

--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -106,16 +106,18 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
          * combine some files on the compilation so the changes in one file can affect another.
          */
         codeLines.Insert(lastIncludeLineIndex + 2, "#undef GetCurrentDirectory");
-
-        // Add logging method.
-        var insertingPosition = GetFirstLineInMethodBody(codeLines, logMethodLineIndex);
-        codeLines.Insert(insertingPosition, "OutputDebugStringW(message->chars);");
 #endif
+        // Add logging method.
         var logMethodLineIndex = SearchForLine(codeLines, "void Debugger::Log");
         if (logMethodLineIndex == -1)
         {
             throw new Exception("Unexpected content of Debugger.cpp");
         }
+
+#if UNITY_VERSION < UNITY_2021
+        var insertingPosition = GetFirstLineInMethodBody(codeLines, logMethodLineIndex);
+        codeLines.Insert(insertingPosition, "OutputDebugStringW(message->chars);");
+#endif
 
         // Enable logging.
         var isLoggingMethodLineIndex = SearchForLine(codeLines, "bool Debugger::IsLogging");

--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -97,6 +97,7 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
             throw new Exception("Unexpected content of Debugger.cpp");
         }
 
+#if UNITY_VERSION < UNITY_2021
         // Add '#include <Windows.h>' which provides 'OutputDebugStringW'.
         codeLines.Insert(lastIncludeLineIndex + 1, "#include <Windows.h>");
 
@@ -107,13 +108,14 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
         codeLines.Insert(lastIncludeLineIndex + 2, "#undef GetCurrentDirectory");
 
         // Add logging method.
+        var insertingPosition = GetFirstLineInMethodBody(codeLines, logMethodLineIndex);
+        codeLines.Insert(insertingPosition, "OutputDebugStringW(message->chars);");
+#endif
         var logMethodLineIndex = SearchForLine(codeLines, "void Debugger::Log");
         if (logMethodLineIndex == -1)
         {
             throw new Exception("Unexpected content of Debugger.cpp");
         }
-        var insertingPosition = GetFirstLineInMethodBody(codeLines, logMethodLineIndex);
-        codeLines.Insert(insertingPosition, "OutputDebugStringW(message->chars);");
 
         // Enable logging.
         var isLoggingMethodLineIndex = SearchForLine(codeLines, "bool Debugger::IsLogging");
@@ -284,9 +286,9 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
         return attribute == null ? null : attribute.Value;
     }
 
-    #endregion
+#endregion
 
-    #region iOS Methods
+#region iOS Methods
     private static void OnPostprocessProject(PBXProjectWrapper project)
     {
         // Need to add SQLite and zlib dependencies.
@@ -336,5 +338,5 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
         }
     }
 
-    #endregion
+#endregion
 }

--- a/Assets/AppCenter/Editor/AppCenterPostBuild.cs
+++ b/Assets/AppCenter/Editor/AppCenterPostBuild.cs
@@ -97,7 +97,6 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
             throw new Exception("Unexpected content of Debugger.cpp");
         }
 
-#if UNITY_VERSION < UNITY_2021
         // Add '#include <Windows.h>' which provides 'OutputDebugStringW'.
         codeLines.Insert(lastIncludeLineIndex + 1, "#include <Windows.h>");
 
@@ -106,7 +105,9 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
          * combine some files on the compilation so the changes in one file can affect another.
          */
         codeLines.Insert(lastIncludeLineIndex + 2, "#undef GetCurrentDirectory");
-#endif
+        codeLines.Insert(lastIncludeLineIndex + 3, "#undef ZeroMemory");
+        codeLines.Insert(lastIncludeLineIndex + 4, "#undef MemoryBarrier");
+
         // Add logging method.
         var logMethodLineIndex = SearchForLine(codeLines, "void Debugger::Log");
         if (logMethodLineIndex == -1)
@@ -114,8 +115,26 @@ public class AppCenterPostBuild : IPostprocessBuildWithReport
             throw new Exception("Unexpected content of Debugger.cpp");
         }
 
-#if UNITY_VERSION < UNITY_2021
         var insertingPosition = GetFirstLineInMethodBody(codeLines, logMethodLineIndex);
+
+        /*
+        var counter = 5;
+        foreach (string s in codeLines)
+        {
+            codeLines.Insert(lastIncludeLineIndex + counter, $"\/* {s} *\/");
+            counter += 1;
+        }
+        */
+
+        var len = codeLines.Count;
+        
+        for (int i = 0; i < len; i++) {
+            codeLines.Insert(lastIncludeLineIndex, codeLines[i]);
+        }
+
+#if UNITY_2021_1_OR_NEWER
+        codeLines.Insert(insertingPosition, "OutputDebugStringW((*message)->chars);");
+#else
         codeLines.Insert(insertingPosition, "OutputDebugStringW(message->chars);");
 #endif
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are the files formatted correctly?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Added compiler condition for Windows.h, #undef GetCurrentDirectory and logging method. 

## Related PRs or issues

[AB#91924](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/91924)
https://github.com/microsoft/appcenter-sdk-unity/issues/513
